### PR TITLE
Fix reader width

### DIFF
--- a/src/components/navbar/ReaderNavBar.tsx
+++ b/src/components/navbar/ReaderNavBar.tsx
@@ -26,7 +26,11 @@ import { useTranslation } from 'react-i18next';
 import { AllowedMetadataValueTypes, ChapterOffset, IReaderSettings, TChapter, TManga } from '@/typings';
 import { ReaderSettingsOptions } from '@/components/reader/ReaderSettingsOptions';
 
-const Root = styled('div')(({ theme }) => ({
+const Root = styled('div')({
+    zIndex: 10,
+});
+
+const NavContainer = styled('div')(({ theme }) => ({
     top: 0,
     left: 0,
     width: '300px',
@@ -198,9 +202,9 @@ export function ReaderNavBar(props: IProps) {
     };
 
     return (
-        <>
+        <Root>
             <Slide direction="right" in={drawerOpen} timeout={200} appear={false} mountOnEnter unmountOnExit>
-                <Root
+                <NavContainer
                     sx={{
                         position: 'fixed',
                     }}
@@ -374,7 +378,7 @@ export function ReaderNavBar(props: IProps) {
                             </Tooltip>
                         </ChapterNavigation>
                     </Navigation>
-                </Root>
+                </NavContainer>
             </Slide>
             <Zoom in={!drawerOpen}>
                 <Fade in={!hideOpenButton}>
@@ -392,6 +396,6 @@ export function ReaderNavBar(props: IProps) {
                     </Tooltip>
                 </Fade>
             </Zoom>
-        </>
+        </Root>
     );
 }

--- a/src/components/reader/DoublePage.tsx
+++ b/src/components/reader/DoublePage.tsx
@@ -33,7 +33,7 @@ export const DoublePage = forwardRef((props: IProps, ref: any) => {
     const spinnerStyle: SxProps<Theme> = {
         ...imgStyle,
         height: '100vh',
-        width: '70vw',
+        width: '50%',
         backgroundColor: '#525252',
     };
 
@@ -61,6 +61,7 @@ export const DoublePage = forwardRef((props: IProps, ref: any) => {
                 imgRef={imgRef}
                 spinnerStyle={{
                     ...spinnerStyle,
+                    width: 'calc(50% - 5px)',
                     marginLeft: '5px',
                 }}
                 imgStyle={imgStyle}

--- a/src/components/reader/DoublePage.tsx
+++ b/src/components/reader/DoublePage.tsx
@@ -39,7 +39,7 @@ export const DoublePage = forwardRef((props: IProps, ref: any) => {
             sx={{
                 display: 'flex',
                 justifyContent: 'center',
-                flexGrow: 1,
+                width: '100%',
             }}
         >
             <SpinnerImage

--- a/src/components/reader/DoublePage.tsx
+++ b/src/components/reader/DoublePage.tsx
@@ -6,26 +6,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { CSSProperties, forwardRef, useRef } from 'react';
+import { forwardRef, useRef } from 'react';
 import { Box, SxProps, Theme } from '@mui/material';
 import { IReaderSettings } from '@/typings';
 import { SpinnerImage } from '@/components/util/SpinnerImage';
-
-const imgStyles: CSSProperties = {
-    display: 'block',
-    marginBottom: 0,
-    width: 'auto',
-    minHeight: '99vh',
-    height: 'auto',
-    maxHeight: '99vh',
-    objectFit: 'contain',
-};
-
-const spinnerStyle: SxProps<Theme> = {
-    ...imgStyles,
-    width: 'calc((100vw - 300px) * 0.5)',
-    backgroundColor: '#525252',
-};
+import { imageStyle } from '@/components/reader/Page';
 
 interface IProps {
     index: number;
@@ -39,18 +24,22 @@ export const DoublePage = forwardRef((props: IProps, ref: any) => {
     const { image1src, image2src, index, onImageLoad, settings } = props;
 
     const imgRef = useRef<HTMLImageElement>(null);
+    const imgStyle = imageStyle(settings);
+
+    const spinnerStyle: SxProps<Theme> = {
+        ...imgStyle,
+        height: '100vh',
+        width: '70vw',
+        backgroundColor: '#525252',
+    };
 
     return (
         <Box
             ref={ref}
             sx={{
                 display: 'flex',
-                flexDirection: settings.readerType === 'DoubleLTR' ? 'row' : 'row-reverse',
                 justifyContent: 'center',
-                margin: '0 auto',
-                width: 'auto',
-                height: 'auto',
-                overflowX: 'scroll',
+                flexGrow: 1,
             }}
         >
             <SpinnerImage
@@ -59,7 +48,7 @@ export const DoublePage = forwardRef((props: IProps, ref: any) => {
                 alt={`Page #${index}`}
                 imgRef={imgRef}
                 spinnerStyle={spinnerStyle}
-                imgStyle={imgStyles}
+                imgStyle={imgStyle}
             />
             <SpinnerImage
                 src={image2src}
@@ -68,10 +57,9 @@ export const DoublePage = forwardRef((props: IProps, ref: any) => {
                 imgRef={imgRef}
                 spinnerStyle={{
                     ...spinnerStyle,
-                    width: 'calc((100vw - 300px - 5px) * 0.5)',
                     marginLeft: '5px',
                 }}
-                imgStyle={imgStyles}
+                imgStyle={imgStyle}
             />
         </Box>
     );

--- a/src/components/reader/DoublePage.tsx
+++ b/src/components/reader/DoublePage.tsx
@@ -24,7 +24,11 @@ export const DoublePage = forwardRef((props: IProps, ref: any) => {
     const { image1src, image2src, index, onImageLoad, settings } = props;
 
     const imgRef = useRef<HTMLImageElement>(null);
-    const imgStyle = imageStyle(settings);
+    const baseImgStyle = imageStyle(settings);
+    const imgStyle = {
+        ...baseImgStyle,
+        width: settings.fitPageToWindow ? baseImgStyle.width : `calc(${baseImgStyle.width} * 0.5)`,
+    };
 
     const spinnerStyle: SxProps<Theme> = {
         ...imgStyle,

--- a/src/components/reader/Page.tsx
+++ b/src/components/reader/Page.tsx
@@ -41,9 +41,9 @@ export function imageStyle(settings: IReaderSettings): any {
             marginLeft: isHorizontal ? '7px' : 0,
             marginRight: isHorizontal ? '7px' : 0,
             width: 'auto',
-            minHeight: '99vh',
+            minHeight: '100vh',
             height: 'auto',
-            maxHeight: '99vh',
+            maxHeight: '100vh',
             objectFit: 'contain',
         };
     }

--- a/src/components/reader/Page.tsx
+++ b/src/components/reader/Page.tsx
@@ -34,7 +34,6 @@ function imageStyle(settings: IReaderSettings): any {
     }, []);
     if (settings.fitPageToWindow || isFillsPageReaderType(settings.readerType)) {
         return {
-            display: 'block',
             marginLeft: '7px',
             marginRight: '7px',
             width: 'auto',
@@ -46,13 +45,11 @@ function imageStyle(settings: IReaderSettings): any {
     }
 
     return {
-        display: 'block',
         marginBottom: settings.readerType === 'ContinuesVertical' ? '15px' : 0,
         minWidth: '10vw',
         width: dimensions.width < dimensions.height ? '100vw' : `${settings.readerWidth}%`,
         maxWidth: '100%',
-        marginLeft: 'auto',
-        marginRight: 'auto',
+        objectFit: 'contain',
     };
 }
 
@@ -71,7 +68,7 @@ export const Page = forwardRef((props: IProps, ref: any) => {
     const imgStyle = imageStyle(settings);
 
     return (
-        <Box ref={ref} sx={{ margin: 'auto' }}>
+        <Box ref={ref} sx={{ display: 'flex', justifyContent: 'center' }}>
             <SpinnerImage
                 src={src}
                 onImageLoad={onImageLoad}

--- a/src/components/reader/Page.tsx
+++ b/src/components/reader/Page.tsx
@@ -11,10 +11,10 @@ import Box from '@mui/material/Box';
 import { IReaderSettings, ReaderType } from '@/typings';
 import { SpinnerImage } from '@/components/util/SpinnerImage';
 
-export const isFillsPageReaderType = (readerType: ReaderType): boolean =>
-    ['DoubleRTL', 'DoubleLTR', 'ContinuesHorizontalLTR', 'ContinuesHorizontalRTL'].includes(readerType);
+export const isHorizontalReaderType = (readerType: ReaderType): boolean =>
+    ['ContinuesHorizontalLTR', 'ContinuesHorizontalRTL'].includes(readerType);
 
-function imageStyle(settings: IReaderSettings): any {
+export function imageStyle(settings: IReaderSettings): any {
     const [dimensions, setDimensions] = useState({
         height: window.innerHeight,
         width: window.innerWidth,
@@ -32,10 +32,12 @@ function imageStyle(settings: IReaderSettings): any {
             window.removeEventListener('resize', handleResize);
         };
     }, []);
-    if (settings.fitPageToWindow || isFillsPageReaderType(settings.readerType)) {
+
+    const isHorizontal = isHorizontalReaderType(settings.readerType);
+    if (settings.fitPageToWindow || isHorizontal) {
         return {
-            marginLeft: '7px',
-            marginRight: '7px',
+            marginLeft: isHorizontal ? '7px' : 0,
+            marginRight: isHorizontal ? '7px' : 0,
             width: 'auto',
             minHeight: '99vh',
             height: 'auto',

--- a/src/components/reader/Page.tsx
+++ b/src/components/reader/Page.tsx
@@ -8,6 +8,8 @@
 
 import { useState, useEffect, forwardRef, useRef } from 'react';
 import Box from '@mui/material/Box';
+import { useTheme } from '@mui/material/styles';
+import { useMediaQuery } from '@mui/material';
 import { IReaderSettings, ReaderType } from '@/typings';
 import { SpinnerImage } from '@/components/util/SpinnerImage';
 
@@ -65,6 +67,9 @@ interface IProps {
 export const Page = forwardRef((props: IProps, ref: any) => {
     const { src, index, onImageLoad, settings } = props;
 
+    const theme = useTheme();
+    const isMobileWidth = useMediaQuery(theme.breakpoints.down('md'));
+
     const imgRef = useRef<HTMLImageElement>(null);
 
     const imgStyle = imageStyle(settings);
@@ -83,7 +88,7 @@ export const Page = forwardRef((props: IProps, ref: any) => {
                 spinnerStyle={{
                     ...imgStyle,
                     height: '100vh',
-                    width: '70vw',
+                    width: isMobileWidth ? '100vw' : 'calc(100% * 0.5)',
                     backgroundColor: '#525252',
                 }}
                 imgStyle={imgStyle}

--- a/src/components/reader/Page.tsx
+++ b/src/components/reader/Page.tsx
@@ -68,9 +68,13 @@ export const Page = forwardRef((props: IProps, ref: any) => {
     const imgRef = useRef<HTMLImageElement>(null);
 
     const imgStyle = imageStyle(settings);
+    const isDoublePageReader = ['DoubleRTL', 'DoubleLTR'].includes(settings.readerType);
 
     return (
-        <Box ref={ref} sx={{ display: 'flex', justifyContent: 'center' }}>
+        <Box
+            ref={ref}
+            sx={{ display: 'flex', justifyContent: 'center', minWidth: isDoublePageReader ? '100%' : undefined }}
+        >
             <SpinnerImage
                 src={src}
                 onImageLoad={onImageLoad}

--- a/src/components/reader/ReaderSettingsOptions.tsx
+++ b/src/components/reader/ReaderSettingsOptions.tsx
@@ -12,7 +12,7 @@ import MenuItem from '@mui/material/MenuItem';
 import { useTranslation } from 'react-i18next';
 import { AllowedMetadataValueTypes, IReaderSettings } from '@/typings';
 import { NumberSetting } from '@/components/settings/NumberSetting.tsx';
-import { isFillsPageReaderType } from '@/components/reader/Page.tsx';
+import { isHorizontalReaderType } from '@/components/reader/Page.tsx';
 
 interface IProps extends IReaderSettings {
     setSettingValue: (key: keyof IReaderSettings, value: AllowedMetadataValueTypes) => void;
@@ -30,7 +30,7 @@ export function ReaderSettingsOptions({
     readerWidth,
 }: IProps) {
     const { t } = useTranslation();
-    const fitPageToWindowEligible = !isFillsPageReaderType(readerType);
+    const fitPageToWindowEligible = !isHorizontalReaderType(readerType);
     return (
         <List>
             <ListItem>

--- a/src/components/reader/pager/DoublePagedPager.tsx
+++ b/src/components/reader/pager/DoublePagedPager.tsx
@@ -178,7 +178,6 @@ export function DoublePagedPager(props: IReaderProps) {
                     margin: '0 auto',
                     width: 'auto',
                     height: 'auto',
-                    overflowX: 'scroll',
                 }}
             >
                 {getPagesToDisplay() === 2 ? (

--- a/src/components/reader/pager/DoublePagedPager.tsx
+++ b/src/components/reader/pager/DoublePagedPager.tsx
@@ -175,7 +175,6 @@ export function DoublePagedPager(props: IReaderProps) {
                     display: 'flex',
                     flexDirection: settings.readerType === 'DoubleLTR' ? 'row' : 'row-reverse',
                     justifyContent: 'center',
-                    margin: '0 auto',
                     width: 'auto',
                     height: 'auto',
                 }}

--- a/src/components/reader/pager/HorizontalPager.tsx
+++ b/src/components/reader/pager/HorizontalPager.tsx
@@ -166,7 +166,6 @@ export function HorizontalPager(props: IReaderProps) {
                 display: 'flex',
                 flexDirection: settings.readerType === 'ContinuesHorizontalLTR' ? 'row' : 'row-reverse',
                 justifyContent: settings.readerType === 'ContinuesHorizontalLTR' ? 'flex-start' : 'flex-end',
-                margin: '0 auto',
                 width: 'auto',
                 height: 'auto',
                 overflowX: 'visible',

--- a/src/components/reader/pager/PagedPager.tsx
+++ b/src/components/reader/pager/PagedPager.tsx
@@ -101,7 +101,6 @@ export function PagedPager(props: IReaderProps) {
                 display: 'flex',
                 flexDirection: 'column',
                 justifyContent: 'center',
-                margin: '0 auto',
                 width: 'auto',
                 height: 'auto',
             }}

--- a/src/components/reader/pager/PagedPager.tsx
+++ b/src/components/reader/pager/PagedPager.tsx
@@ -99,11 +99,11 @@ export function PagedPager(props: IReaderProps) {
             ref={selfRef}
             sx={{
                 display: 'flex',
-                flexDirection: 'row',
+                flexDirection: 'column',
                 justifyContent: 'center',
                 margin: '0 auto',
-                width: '100%',
-                height: '100vh',
+                width: 'auto',
+                height: 'auto',
             }}
             onClick={clickControl}
         >

--- a/src/components/reader/pager/VerticalPager.tsx
+++ b/src/components/reader/pager/VerticalPager.tsx
@@ -174,7 +174,8 @@ export function VerticalPager(props: IReaderProps) {
                 flexDirection: 'column',
                 justifyContent: 'center',
                 margin: '0 auto',
-                width: '100%',
+                width: 'auto',
+                height: 'auto',
                 userSelect: 'none',
             }}
             onClick={(e) => {

--- a/src/components/reader/pager/VerticalPager.tsx
+++ b/src/components/reader/pager/VerticalPager.tsx
@@ -173,7 +173,6 @@ export function VerticalPager(props: IReaderProps) {
                 display: 'flex',
                 flexDirection: 'column',
                 justifyContent: 'center',
-                margin: '0 auto',
                 width: 'auto',
                 height: 'auto',
                 userSelect: 'none',

--- a/src/screens/Reader.tsx
+++ b/src/screens/Reader.tsx
@@ -400,7 +400,12 @@ export function Reader() {
     return (
         <Box
             sx={{
-                width: settings.staticNav ? 'calc(100vw - 300px)' : '100vw',
+                display: 'flex',
+                flexDirection: 'column',
+                alignContent: 'center',
+                justifyContent: 'center',
+                minWidth: settings.staticNav ? 'calc((100vw - (100vw - 100%)) - 300px)' : '100vw - (100vw - 100%)', // 100vw = width excluding scrollbar; 100% = width including scrollbar
+                minHeight: '100vh',
                 marginLeft: settings.staticNav ? '300px' : 'unset',
             }}
         >

--- a/src/util/readerSettings.ts
+++ b/src/util/readerSettings.ts
@@ -25,7 +25,7 @@ export const getDefaultSettings = (): IReaderSettings => ({
     showPageNumber: true,
     loadNextOnEnding: false,
     skipDupChapters: true,
-    fitPageToWindow: false,
+    fitPageToWindow: true,
     readerType: 'ContinuesVertical',
     offsetFirstPage: false,
     readerWidth: 100,


### PR DESCRIPTION
The margin: auto on the Box container for the image was preventing 100% width to actually mean 100%.

Now that 100% is actually possible, I think fitPageToWindow makes more sense as a default. Additionally, since the image can fill 100% of the page, it can cover the ReaderNavBar, so set the z-index of the ReaderNavBar so it's rendered on top of the image and clickable.

## Before.

Notice 100%, is not actually taking 100% of the page width.

<img width="1512" alt="Screenshot 2024-01-23 at 7 07 17 PM" src="https://github.com/Suwayomi/Suwayomi-WebUI/assets/1400401/24d32607-cf3f-49af-a0de-2fd783971357">

## After:

fit to page width
<img width="1512" alt="Screenshot 2024-01-23 at 7 04 21 PM" src="https://github.com/Suwayomi/Suwayomi-WebUI/assets/1400401/0e593011-38bd-409a-bb1e-fc0edc6a5a8a">

21% width
<img width="1512" alt="Screenshot 2024-01-23 at 7 04 14 PM" src="https://github.com/Suwayomi/Suwayomi-WebUI/assets/1400401/93ddc969-e7a9-44aa-8cee-556d92b8ef17">

100% width
<img width="1509" alt="Screenshot 2024-01-23 at 7 04 06 PM" src="https://github.com/Suwayomi/Suwayomi-WebUI/assets/1400401/3b983ae5-ea56-43f5-b1c1-911c819fd846">
