### PR TITLE
[Codegen] Update manga chapter total count on initial refresh

### DIFF
--- a/src/lib/graphql/generated/graphql.ts
+++ b/src/lib/graphql/generated/graphql.ts
@@ -2594,7 +2594,7 @@ export type GetMangaChaptersFetchMutationVariables = Exact<{
 }>;
 
 
-export type GetMangaChaptersFetchMutation = { __typename?: 'Mutation', fetchChapters: { __typename?: 'FetchChaptersPayload', clientMutationId?: string | null, chapters: Array<{ __typename?: 'ChapterType', chapterNumber: number, fetchedAt: any, id: number, isBookmarked: boolean, isDownloaded: boolean, isRead: boolean, lastPageRead: number, lastReadAt: any, name: string, pageCount: number, realUrl?: string | null, scanlator?: string | null, sourceOrder: number, uploadDate: any, url: string, manga: { __typename?: 'MangaType', id: number, title: string, inLibrary: boolean, thumbnailUrl?: string | null }, meta: Array<{ __typename?: 'ChapterMetaType', key: string, value: string }> }> } };
+export type GetMangaChaptersFetchMutation = { __typename?: 'Mutation', fetchChapters: { __typename?: 'FetchChaptersPayload', clientMutationId?: string | null, chapters: Array<{ __typename?: 'ChapterType', chapterNumber: number, fetchedAt: any, id: number, isBookmarked: boolean, isDownloaded: boolean, isRead: boolean, lastPageRead: number, lastReadAt: any, name: string, pageCount: number, realUrl?: string | null, scanlator?: string | null, sourceOrder: number, uploadDate: any, url: string, manga: { __typename?: 'MangaType', id: number, title: string, inLibrary: boolean, thumbnailUrl?: string | null, chapters: { __typename?: 'ChapterNodeList', totalCount: number } }, meta: Array<{ __typename?: 'ChapterMetaType', key: string, value: string }> }> } };
 
 export type SetChapterMetadataMutationVariables = Exact<{
   input: SetChapterMetaInput;

--- a/src/lib/graphql/mutations/ChapterMutation.ts
+++ b/src/lib/graphql/mutations/ChapterMutation.ts
@@ -57,6 +57,12 @@ export const GET_MANGA_CHAPTERS_FETCH = gql`
             clientMutationId
             chapters {
                 ...FULL_CHAPTER_FIELDS
+                manga {
+                    id
+                    chapters {
+                        totalCount
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
In case a manga hadn't been initialized yet, its chapter total count was still 0 after refreshing the manga and its chapter list data. This was caused because its chapter list hadn't been fetched yet by the time the manga refresh mutation resolved.

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->