### PR TITLE
Set default value for resetting reader width to 50%

### DIFF
--- a/src/components/reader/ReaderSettingsOptions.tsx
+++ b/src/components/reader/ReaderSettingsOptions.tsx
@@ -92,7 +92,7 @@ export function ReaderSettingsOptions({
                     value={readerWidth}
                     minValue={10}
                     maxValue={100}
-                    defaultValue={100}
+                    defaultValue={50}
                     valueUnit="%"
                     showSlider
                     handleUpdate={(width: number) => setSettingValue('readerWidth', width)}


### PR DESCRIPTION
Should have been updated along with 2dab88eb7ef26eba29c96c9bbf6ef13fce95eea6

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->