### PR TITLE
decrease reader's up and down arrows scrolling distance

### DIFF
--- a/src/components/reader/pager/VerticalPager.tsx
+++ b/src/components/reader/pager/VerticalPager.tsx
@@ -149,7 +149,7 @@ export function VerticalPager(props: IReaderProps) {
                 case 'ArrowUp':
                     e.preventDefault();
                     go(e.shiftKey ? 'down' : 'up', SCROLL_OFFSET_SLIGHT);
-                    break;          
+                    break;
                 case 'ArrowLeft':
                     e.preventDefault();
                     go(e.shiftKey ? 'down' : 'up');

--- a/src/components/reader/pager/VerticalPager.tsx
+++ b/src/components/reader/pager/VerticalPager.tsx
@@ -137,12 +137,10 @@ export function VerticalPager(props: IReaderProps) {
                     e.preventDefault();
                     go(e.shiftKey ? 'up' : 'down');
                     break;
-                case 'ArrowDown':
                 case 'ArrowRight':
                     e.preventDefault();
                     go(e.shiftKey ? 'up' : 'down');
                     break;
-                case 'ArrowUp':
                 case 'ArrowLeft':
                     e.preventDefault();
                     go(e.shiftKey ? 'down' : 'up');

--- a/src/components/reader/pager/VerticalPager.tsx
+++ b/src/components/reader/pager/VerticalPager.tsx
@@ -112,7 +112,7 @@ export function VerticalPager(props: IReaderProps) {
     }, [selfRef]);
 
     const go = useCallback(
-        (direction: 'up' | 'down', slightly = false) => {
+        (direction: 'up' | 'down', offset: number = SCROLL_OFFSET) => {
             if (direction === 'down' && isAtBottom()) {
                 nextChapter();
                 return;
@@ -124,7 +124,7 @@ export function VerticalPager(props: IReaderProps) {
             }
 
             window.scroll({
-                top: window.scrollY + window.innerHeight * (slightly ? SCROLL_OFFSET_SLIGHT : SCROLL_OFFSET) * (direction === 'up' ? -1 : 1),
+                top: window.scrollY + window.innerHeight * offset * (direction === 'up' ? -1 : 1),
                 behavior: SCROLL_BEHAVIOR,
             });
         },
@@ -140,7 +140,7 @@ export function VerticalPager(props: IReaderProps) {
                     break;
                 case 'ArrowDown':
                     e.preventDefault();
-                    go(e.shiftKey ? 'up' : 'down', true);
+                    go(e.shiftKey ? 'up' : 'down', SCROLL_OFFSET_SLIGHT);
                     break;
                 case 'ArrowRight':
                     e.preventDefault();
@@ -148,7 +148,7 @@ export function VerticalPager(props: IReaderProps) {
                     break;
                 case 'ArrowUp':
                     e.preventDefault();
-                    go(e.shiftKey ? 'down' : 'up', true);
+                    go(e.shiftKey ? 'down' : 'up', SCROLL_OFFSET_SLIGHT);
                     break;          
                 case 'ArrowLeft':
                     e.preventDefault();

--- a/src/components/reader/pager/VerticalPager.tsx
+++ b/src/components/reader/pager/VerticalPager.tsx
@@ -24,7 +24,8 @@ const findCurrentPageIndex = (wrapper: HTMLDivElement): number => {
 
 // TODO: make configurable?
 const SCROLL_SAFE_ZONE = 5; // px
-const SCROLL_OFFSET = 0.95;
+const SCROLL_OFFSET = 0.95; // left and right arrows
+const SCROLL_OFFSET_SLIGHT = 0.25; // up and down arrows
 const SCROLL_BEHAVIOR: ScrollBehavior = 'smooth';
 
 const isAtBottom = () => {
@@ -111,7 +112,7 @@ export function VerticalPager(props: IReaderProps) {
     }, [selfRef]);
 
     const go = useCallback(
-        (direction: 'up' | 'down') => {
+        (direction: 'up' | 'down', slightly = false) => {
             if (direction === 'down' && isAtBottom()) {
                 nextChapter();
                 return;
@@ -123,7 +124,7 @@ export function VerticalPager(props: IReaderProps) {
             }
 
             window.scroll({
-                top: window.scrollY + window.innerHeight * SCROLL_OFFSET * (direction === 'up' ? -1 : 1),
+                top: window.scrollY + window.innerHeight * (slightly ? SCROLL_OFFSET_SLIGHT : SCROLL_OFFSET) * (direction === 'up' ? -1 : 1),
                 behavior: SCROLL_BEHAVIOR,
             });
         },
@@ -137,10 +138,18 @@ export function VerticalPager(props: IReaderProps) {
                     e.preventDefault();
                     go(e.shiftKey ? 'up' : 'down');
                     break;
+                case 'ArrowDown':
+                    e.preventDefault();
+                    go(e.shiftKey ? 'up' : 'down', true);
+                    break;
                 case 'ArrowRight':
                     e.preventDefault();
                     go(e.shiftKey ? 'up' : 'down');
                     break;
+                case 'ArrowUp':
+                    e.preventDefault();
+                    go(e.shiftKey ? 'down' : 'up', true);
+                    break;          
                 case 'ArrowLeft':
                     e.preventDefault();
                     go(e.shiftKey ? 'down' : 'up');

--- a/src/components/reader/pager/VerticalPager.tsx
+++ b/src/components/reader/pager/VerticalPager.tsx
@@ -24,8 +24,8 @@ const findCurrentPageIndex = (wrapper: HTMLDivElement): number => {
 
 // TODO: make configurable?
 const SCROLL_SAFE_ZONE = 5; // px
-const SCROLL_OFFSET = 0.95; // left and right arrows
-const SCROLL_OFFSET_SLIGHT = 0.25; // up and down arrows
+const SCROLL_OFFSET = 0.95;
+const SCROLL_OFFSET_SLIGHT = 0.25;
 const SCROLL_BEHAVIOR: ScrollBehavior = 'smooth';
 
 const isAtBottom = () => {


### PR DESCRIPTION
<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->

The up and down arrow keys now function similarly to the left and right arrows; they scroll the reader to a specific image/position. Whereas previously, the up and down arrows provided more control, allowing for scrolling only a few pixels at a time (a native browser function).

This change might appear subjective, but the previous behavior provided greater control.

Partially revert PR #452.