### PR TITLE
Correctly update cache after updating an extension

### DIFF
--- a/src/lib/requests/RequestManager.ts
+++ b/src/lib/requests/RequestManager.ts
@@ -1100,8 +1100,12 @@ export class RequestManager {
                         ...cachedExtensions.data.fetchExtensions,
                         extensions: cachedExtensions.data.fetchExtensions.extensions
                             .filter((extension) => {
+                                if (!isObsolete) {
+                                    return true;
+                                }
+
                                 const isUpdatedExtension = id === extension.pkgName;
-                                return isUpdatedExtension && !isObsolete;
+                                return !isUpdatedExtension;
                             })
                             .map((extension) => {
                                 const isUpdatedExtension = id === extension.pkgName;


### PR DESCRIPTION
After installing/uninstalling/updating an extension all other extension were removed from the list besides the updated extension

Regression introduced with 506e0aa0e38c0bcb26931b85ef1d6d688b2d95ca

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->