### PR TITLE
Handle backup creation on same domain as server

### DIFF
--- a/src/screens/settings/Backup.tsx
+++ b/src/screens/settings/Backup.tsx
@@ -227,7 +227,7 @@ export function Backup() {
     return (
         <>
             <List sx={{ padding: 0 }}>
-                <ListItemLink to={requestManager.getExportBackupUrl()}>
+                <ListItemLink to={requestManager.getExportBackupUrl()} download target="_self">
                     <ListItemText
                         primary={t('settings.backup.action.create.label.title')}
                         secondary={t('settings.backup.action.create.label.description')}


### PR DESCRIPTION
In case the webUI is hosted by the server the backup creation caused the app to navigate to the backup url which resulted in an empty page

Regression introduced with db5d3ff7c0062257f7096df906bdcee84a98c17e

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->