### PR TITLE
Handle RTL reading direction for double page reader

### DIFF
--- a/src/components/reader/DoublePage.tsx
+++ b/src/components/reader/DoublePage.tsx
@@ -42,6 +42,7 @@ export const DoublePage = forwardRef((props: IProps, ref: any) => {
             ref={ref}
             sx={{
                 display: 'flex',
+                flexDirection: settings.readerType === 'DoubleLTR' ? 'row' : 'row-reverse',
                 justifyContent: 'center',
                 width: '100%',
             }}


### PR DESCRIPTION
Changing the reading direction for the double page reader did nothing. It just always was LTR.

Regression introduced with 4d75474b39b1fda4c3e33e1fd58fce6df1e8db30

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->