### PR TITLE
Add info text to download ahead setting

### DIFF
--- a/src/components/settings/downloads/DownloadAheadSetting.tsx
+++ b/src/components/settings/downloads/DownloadAheadSetting.tsx
@@ -69,6 +69,7 @@ export const DownloadAheadSetting = () => {
                 defaultValue={DEFAULT_LIMIT}
                 showSlider
                 dialogDescription={t('download.settings.download_ahead.label.description')}
+                dialogDisclaimer={t('download.settings.download_ahead.label.disclaimer')}
                 valueUnit={t('chapter.title')}
                 handleUpdate={updateSetting}
                 disabled={!shouldDownloadAhead}

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -202,7 +202,8 @@
       },
       "download_ahead": {
         "label": {
-          "description": "How many chapters should get downloaded when marking a chapter as read while reading.",
+          "description": "How many chapters should get downloaded while reading.",
+          "disclaimer": "Only works if the current chapter plus the next chapter are already downloaded.",
           "unread_chapters_to_download": "Number of unread chapters to download",
           "value": "{{chapters}} $t(chapter.title)",
           "while_reading": "Auto download while reading"


### PR DESCRIPTION
Show info that current and next chapter have to be downloaded for this setting to work

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->