### PR TITLE
Fix size of pages in continues reader mode

### DIFF
--- a/src/components/reader/Page.tsx
+++ b/src/components/reader/Page.tsx
@@ -24,8 +24,9 @@ export function imageStyle(settings: IReaderSettings): any {
             marginRight: isHorizontal ? '7px' : 0,
             marginBottom: settings.readerType === 'ContinuesVertical' ? '15px' : 0,
             width: 'auto',
-            maxWidth: settings.fitPageToWindow ? 'calc(100vw - (100vw - 100%))' : undefined,
+            maxWidth: settings.fitPageToWindow && !isHorizontal ? 'calc(100vw - (100vw - 100%))' : undefined,
             height: 'auto',
+            minHeight: isHorizontal ? '100vh' : undefined,
             maxHeight: '100vh',
             objectFit: 'contain',
         };


### PR DESCRIPTION
In case "fit to page" was enabled, the styling got incorrectly applied to horizontal pages. Causing the pages to be small

Regression introduced with 15825fbe530bf1de58565db63545341b84225da9

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->