### PR TITLE
Use full available width for reader component

### DIFF
--- a/src/screens/Reader.tsx
+++ b/src/screens/Reader.tsx
@@ -423,19 +423,21 @@ export function Reader() {
             }}
         >
             <PageNumber settings={settings} curPage={curPage} pageCount={chapter.pageCount} />
-            <ReaderComponent
-                key={chapter.id}
-                pages={pages}
-                pageCount={chapter.pageCount}
-                setCurPage={setCurPage}
-                initialPage={initialPage}
-                curPage={curPage}
-                settings={settings}
-                manga={manga}
-                chapter={chapter}
-                nextChapter={loadNextChapter}
-                prevChapter={loadPrevChapter}
-            />
+            <Box sx={{ alignSelf: 'stretch' }}>
+                <ReaderComponent
+                    key={chapter.id}
+                    pages={pages}
+                    pageCount={chapter.pageCount}
+                    setCurPage={setCurPage}
+                    initialPage={initialPage}
+                    curPage={curPage}
+                    settings={settings}
+                    manga={manga}
+                    chapter={chapter}
+                    nextChapter={loadNextChapter}
+                    prevChapter={loadPrevChapter}
+                />
+            </Box>
         </Box>
     );
 }


### PR DESCRIPTION
Due to horizontally centering the flex-box items via "alignItems", the items did not stretch anymore, which is the default value for "alignItems" and thus, did not take up the available width.

Regression introduced with ab0ecf4da0a2511fd0a8d8885bce07e53dfd5840

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->