### PR TITLE
Prevent unnecessary chapter updates due to restoring last read page

### DIFF
--- a/src/screens/Reader.tsx
+++ b/src/screens/Reader.tsx
@@ -355,6 +355,11 @@ export function Reader() {
             return;
         }
 
+        const chapterUpToDate = Chapters.getFromCache<TChapter>(chapter.id);
+        if (curPageDebounced === chapterUpToDate?.lastPageRead) {
+            return;
+        }
+
         // do not mutate the chapter, this will cause the page to jump around due to always scrolling to the last read page
         const updateLastPageRead = curPageDebounced !== -1;
         const updateIsRead = curPageDebounced === chapter.pageCount - 1;


### PR DESCRIPTION
When resuming a chapter and restoring the last read page, a chapter update was send for the just restored page

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->