### PR TITLE
Revoke object url only on unmount

### DIFF
--- a/src/components/util/SpinnerImage.tsx
+++ b/src/components/util/SpinnerImage.tsx
@@ -48,6 +48,7 @@ export const SpinnerImage = forwardRef((props: IProps, imgRef: ForwardedRef<HTML
     };
 
     useEffect(() => {
+        let tmpImageSourceUrl: string;
         const imageRequest = requestManager.requestImage(src);
 
         const fetchImage = async () => {
@@ -57,6 +58,7 @@ export const SpinnerImage = forwardRef((props: IProps, imgRef: ForwardedRef<HTML
 
                     updateImageState(false);
                     setImageSourceUrl(image);
+                    tmpImageSourceUrl = image;
                 };
 
                 const checkCache = await Promise.race([imageRequest.response, Promise.resolve(false)]);
@@ -78,6 +80,9 @@ export const SpinnerImage = forwardRef((props: IProps, imgRef: ForwardedRef<HTML
         fetchImage().catch(defaultPromiseErrorHandler);
 
         return () => {
+            if (tmpImageSourceUrl) {
+                URL.revokeObjectURL(tmpImageSourceUrl);
+            }
             imageRequest.abortRequest(new Error('Component was unmounted'));
         };
     }, [imgLoadRetryKey]);
@@ -116,7 +121,6 @@ export const SpinnerImage = forwardRef((props: IProps, imgRef: ForwardedRef<HTML
                 }}
                 ref={imgRef}
                 src={imageSourceUrl}
-                onLoad={() => URL.revokeObjectURL(imageSourceUrl)}
                 alt={alt}
                 draggable={false}
             />


### PR DESCRIPTION
After the object url has been revoked the image can't be used anymore

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->