### PR TITLE
Disconnect resize observer after restoring initial page

### DIFF
--- a/src/components/reader/pager/HorizontalPager.tsx
+++ b/src/components/reader/pager/HorizontalPager.tsx
@@ -115,6 +115,7 @@ export function HorizontalPager(props: IReaderProps) {
 
         const resizeObserver = new ResizeObserver(() => {
             initialPageElement.scrollIntoView({ inline: 'center' });
+            resizeObserver.disconnect();
         });
         resizeObserver.observe(initialPageElement);
 

--- a/src/components/reader/pager/VerticalPager.tsx
+++ b/src/components/reader/pager/VerticalPager.tsx
@@ -173,6 +173,7 @@ export function VerticalPager(props: IReaderProps) {
 
         const resizeObserver = new ResizeObserver(() => {
             initialPageElement.scrollIntoView();
+            resizeObserver.disconnect();
         });
         resizeObserver.observe(initialPageElement);
 


### PR DESCRIPTION
Everytime the reader width got changed, the resize observer triggered the initial page to get scrolled into view again

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->