### PR TITLE
Add prioritization to image requests

### DIFF
--- a/src/components/util/SpinnerImage.tsx
+++ b/src/components/util/SpinnerImage.tsx
@@ -16,6 +16,7 @@ import RefreshIcon from '@mui/icons-material/Refresh';
 import { useTranslation } from 'react-i18next';
 import { requestManager } from '@/lib/requests/RequestManager.ts';
 import { defaultPromiseErrorHandler } from '@/util/defaultPromiseErrorHandler.ts';
+import { Priority } from '@/lib/Queue.ts';
 
 interface IProps {
     src: string;
@@ -48,7 +49,7 @@ export const SpinnerImage = forwardRef((props: IProps, imgRef: ForwardedRef<HTML
 
     useEffect(() => {
         let tmpImageSourceUrl: string;
-        const imageRequest = requestManager.requestImage(src);
+        const imageRequest = requestManager.requestImage(src, Priority.HIGH);
         let cacheTimeout: NodeJS.Timeout;
 
         const fetchImage = async () => {

--- a/src/lib/ControlledPromise.ts
+++ b/src/lib/ControlledPromise.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+export class ControlledPromise<T = void> {
+    private orgResolve!: (value: T | PromiseLike<T>) => void;
+
+    private orgReject!: (reason?: any) => void;
+
+    public readonly promise: Promise<T>;
+
+    constructor() {
+        this.promise = new Promise<T>((resolve, reject) => {
+            this.orgResolve = resolve;
+            this.orgReject = reject;
+        });
+    }
+
+    resolve(value: T): void {
+        this.orgResolve(value);
+    }
+
+    reject(reason?: any): void {
+        this.orgReject(reason);
+    }
+}

--- a/src/lib/Queue.ts
+++ b/src/lib/Queue.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import pLimit, { LimitFunction } from 'p-limit';
+import { ControlledPromise } from '@/lib/ControlledPromise.ts';
+
+export enum Priority {
+    LOW = 0,
+    NORMAL = 1,
+    HIGH = 2,
+}
+export type QueuePriority = Priority | number;
+
+type Key = string;
+type QueueItemFunction<T = any> = () => PromiseLike<T> | T;
+
+export class Queue {
+    private readonly queue: LimitFunction;
+
+    private counter: number = 0;
+
+    private pendingKeyToPriorityMap = new Map<Key, QueuePriority>();
+
+    private pendingKeyToFnMap = new Map<Key, QueueItemFunction>();
+
+    private pendingKeyToPromiseMap = new Map<Key, ControlledPromise<any>>();
+
+    constructor(concurrency: number) {
+        this.queue = pLimit(concurrency);
+    }
+
+    enqueue<T>(key: Key, fn: () => PromiseLike<T> | T, priority: QueuePriority = Priority.NORMAL): Promise<T> {
+        this.counter = (this.counter + 1) % Infinity;
+        const actualKey = `${key}_${this.counter}`;
+
+        this.pendingKeyToPriorityMap.set(actualKey, priority);
+        this.pendingKeyToFnMap.set(actualKey, fn);
+
+        const processPromise = new ControlledPromise<T>();
+        this.pendingKeyToPromiseMap.set(actualKey, processPromise);
+
+        this.queue(() => this.process());
+
+        return processPromise.promise;
+    }
+
+    private async process(): Promise<void> {
+        const { fn, promise } = this.getNextItemToProcess();
+        try {
+            const result = await fn();
+            promise.resolve(result);
+        } catch (e) {
+            promise.reject(e);
+        }
+    }
+
+    private getNextItemToProcess<T>(): { key: Key; fn: QueueItemFunction<T>; promise: ControlledPromise<T> } {
+        const [key] = [...this.pendingKeyToPriorityMap.entries()].toSorted(
+            ([, priorityA], [, priorityB]) => priorityB - priorityA,
+        )[0];
+        const fn = this.pendingKeyToFnMap.get(key) as () => PromiseLike<T> | T;
+        const promise = this.pendingKeyToPromiseMap.get(key) as ControlledPromise<T>;
+
+        this.pendingKeyToPriorityMap.delete(key);
+        this.pendingKeyToFnMap.delete(key);
+        this.pendingKeyToPromiseMap.delete(key);
+
+        return { key, fn, promise };
+    }
+}


### PR DESCRIPTION
In the reader the preloaded page requests were triggered before the actual page got rendered and thus, the image request of the rendered page had to wait for all the preloaded images to finish

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->