### PR TITLE
Use correct chapter list for guard condition

### DIFF
--- a/src/components/chapter/ChapterActionMenuItems.tsx
+++ b/src/components/chapter/ChapterActionMenuItems.tsx
@@ -109,11 +109,6 @@ export const ChapterActionMenuItems = ({
             }
         }
 
-        if (!chaptersWithMeta.length) {
-            onClose();
-            return;
-        }
-
         const getChapters = (): (ChapterDownloadInfo & ChapterBookmarkInfo & ChapterReadInfo)[] => {
             // select mode
             if (!chapter) {
@@ -133,6 +128,13 @@ export const ChapterActionMenuItems = ({
 
             return allChapters.slice(index + 1);
         };
+
+        const chapters = getChapters();
+
+        if (!chapters.length) {
+            onClose();
+            return;
+        }
 
         Chapters.performAction(actualAction, chapter ? [chapter.id] : ChaptersWithMeta.getIds(chaptersWithMeta), {
             chapters: getChapters(),


### PR DESCRIPTION
In case of the "mark_prev_read" as read action, the passed chapter list was empty and thus the guard to exit early was incorrectly triggered

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->