### PR TITLE
Refetch GET_MANGAS query on track unbind mutation

### DIFF
--- a/src/lib/requests/RequestManager.ts
+++ b/src/lib/requests/RequestManager.ts
@@ -2482,7 +2482,7 @@ export class RequestManager {
             GQLMethod.MUTATION,
             TRACKER_UPDATE_BIND,
             { input: { ...patch, recordId: id } },
-            { refetchQueries: patch.unbind ? [GET_MANGA, GET_CATEGORY_MANGAS] : undefined, ...options },
+            { refetchQueries: patch.unbind ? [GET_MANGA, GET_CATEGORY_MANGAS, GET_MANGAS] : undefined, ...options },
         );
     }
 }


### PR DESCRIPTION
GET_CATEGORY_MANGAS is only used for the default category

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->