### PR TITLE
refactor(tracker): changes the logic of calling the TRACKER_FETCH_BIND to the onclick of the tracker button to follow mihon behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ build/*
 tools/scripts/github_token.json
 
 src/lib/graphql/schema.json
+
+# local dev
+pnpm-lock.yaml
+compose.yml

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "ci": "yarn install --frozen-lockfile",
-    "dev": "vite",
+    "dev": "vite --host",
     "preview": "vite preview",
     "build": "vite build",
     "test": "node -e \"console.log('imagine')\"",

--- a/src/components/manga/MangaDetails.tsx
+++ b/src/components/manga/MangaDetails.tsx
@@ -183,6 +183,13 @@ export const MangaDetails: React.FC<IProps> = ({ manga }) => {
     const [isCategorySelectOpen, setIsCategorySelectOpen] = useState(false);
 
     useEffect(() => {
+        manga.trackRecords.nodes.map((trackRecord) =>
+            requestManager
+                .fetchTrackBind(trackRecord.id)
+                .response.catch(() => makeToast(t('tracking.error.label.could_not_fetch_track_info'), 'error')),
+        );
+    }, []);
+    useEffect(() => {
         if (!manga.source) {
             makeToast(translate('source.error.label.source_not_found'), 'error');
         }

--- a/src/components/manga/TrackMangaButton.tsx
+++ b/src/components/manga/TrackMangaButton.tsx
@@ -30,6 +30,11 @@ export const TrackMangaButton = ({ manga }: { manga: TManga }) => {
     const trackersInUse = Trackers.getLoggedIn(Trackers.getTrackers(mangaTrackers));
 
     const handleClick = (openPopup: () => void) => {
+        mangaTrackers.map((trackRecord) =>
+            requestManager
+                .fetchTrackBind(trackRecord.id)
+                .response.catch(() => makeToast(t('tracking.error.label.could_not_fetch_track_info'), 'error')),
+        );
         if (trackerList.error) {
             makeToast(t('tracking.error.label.could_not_load_track_info'), 'error');
             return;

--- a/src/components/tracker/TrackerActiveCard.tsx
+++ b/src/components/tracker/TrackerActiveCard.tsx
@@ -29,7 +29,7 @@ import {
 } from '@mui/material';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import PopupState, { bindDialog, bindMenu, bindTrigger } from 'material-ui-popup-state';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { requestManager } from '@/lib/requests/RequestManager.ts';
 import { Trackers, TTrackRecord, UNSET_DATE } from '@/lib/data/Trackers.ts';
 import { ListPreference } from '@/components/sourceConfiguration/ListPreference.tsx';
@@ -234,12 +234,6 @@ export const TrackerActiveCard = ({
             .updateTrackerBind(trackRecord.id, patch)
             .response.catch(() => makeToast(t('global.error.label.failed_to_save_changes'), 'error'));
     };
-
-    useEffect(() => {
-        requestManager
-            .fetchTrackBind(trackRecord.id)
-            .response.catch(() => makeToast(t('tracking.error.label.could_not_fetch_track_info'), 'error'));
-    }, [trackRecord.id]);
 
     return (
         <Card sx={CARD_STYLING}>


### PR DESCRIPTION
This pull request refactors the logic of calling the TRACKER_FETCH_BIND to the onclick of the tracker button to follow mihon behavior. It also updates the useEffect hook to fetch track info on component mount.