### PR TITLE
Wait for initial page to be rendered before scrolling it into view

### DIFF
--- a/src/components/reader/pager/HorizontalPager.tsx
+++ b/src/components/reader/pager/HorizontalPager.tsx
@@ -114,6 +114,10 @@ export function HorizontalPager(props: IReaderProps) {
         }
 
         const resizeObserver = new ResizeObserver(() => {
+            if (!initialPageElement.offsetHeight) {
+                return;
+            }
+
             initialPageElement.scrollIntoView({ inline: 'center' });
             resizeObserver.disconnect();
         });

--- a/src/components/reader/pager/VerticalPager.tsx
+++ b/src/components/reader/pager/VerticalPager.tsx
@@ -172,6 +172,10 @@ export function VerticalPager(props: IReaderProps) {
         }
 
         const resizeObserver = new ResizeObserver(() => {
+            if (!initialPageElement.offsetHeight) {
+                return;
+            }
+
             initialPageElement.scrollIntoView();
             resizeObserver.disconnect();
         });


### PR DESCRIPTION
The ResizeObserver triggers the first time when the element has a height of 0, which apparently did not work with scrolling it into view.

Due to immediately disconnecting the observer, the next resize event, which would successfully scroll the page into view, was never handled

Regression introduced with 0c1abebaf47b0cd92c0f32cad316e867e96e322c

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->