### PR TITLE
Prevent TypeError

### DIFF
--- a/src/components/MangaGrid.tsx
+++ b/src/components/MangaGrid.tsx
@@ -283,8 +283,8 @@ export const MangaGrid: React.FC<IMangaGridProps> = (props) => {
             return () => {};
         }
 
-        const resizeObserver = new ResizeObserver(() => {
-            const gridHeight = gridRef.current!.offsetHeight;
+        const resizeObserver = new ResizeObserver((entries) => {
+            const gridHeight = entries[0].target.clientHeight;
             const isScrollbarVisible = gridHeight > document.documentElement.clientHeight;
 
             if (!gridHeight) {


### PR DESCRIPTION
Somehow the grid ref was undefined after the resize observer was already connected. This should not be possible, so just disconnect the observer in case this still happens

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->