### PR TITLE
feat(request class): adds header to send cookies, and other auths with every request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ build/*
 tools/scripts/github_token.json
 
 src/lib/graphql/schema.json
+# local dev
+compose.*
+pnpm*.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,3 @@ build/*
 tools/scripts/github_token.json
 
 src/lib/graphql/schema.json
-# local dev
-compose.*
-pnpm*.yaml

--- a/src/lib/requests/client/GraphQLClient.ts
+++ b/src/lib/requests/client/GraphQLClient.ts
@@ -138,7 +138,7 @@ export class GraphQLClient extends BaseClient<
     }
 
     private createUploadLink() {
-        return createUploadLink({ uri: () => this.getBaseUrl() });
+        return createUploadLink({ uri: () => this.getBaseUrl(), credentials: 'include' });
     }
 
     private createWSLink() {

--- a/src/lib/requests/client/RestClient.ts
+++ b/src/lib/requests/client/RestClient.ts
@@ -27,7 +27,9 @@ export class RestClient
     extends BaseClient<typeof fetch, RequestInit, (url: string, data: any) => Promise<Response>>
     implements IRestClient
 {
-    private config: RequestInit = {};
+    private config: RequestInit = {
+        credentials: 'include',
+    };
 
     public readonly fetcher = async (
         url: string,


### PR DESCRIPTION
This pull request adds a header to send cookies and other authentication information with every request. 
- It updates to the GraphQLClient and RestClient classes to handle credentials and include them in the requests.


**References**
- The `Access-Control-Allow-Origin` needs to be set, without using wildcare (`*`), [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin).
- [Apollo Client Authentication](https://www.apollographql.com/docs/react/networking/authentication/) documentation.
- [Traefik cors](https://doc.traefik.io/traefik/middlewares/http/headers/#cors-headers) example.
