### PR TITLE
Allow editing SOCKS and basic auth settings while disabled

### DIFF
--- a/src/screens/settings/ServerSettings.tsx
+++ b/src/screens/settings/ServerSettings.tsx
@@ -159,31 +159,26 @@ export const ServerSettings = () => {
                         [5, { text: '5' }],
                     ]}
                     handleChange={(socksProxyVersion) => updateSetting('socksProxyVersion', socksProxyVersion)}
-                    disabled={!serverSettings?.socksProxyEnabled}
                 />
                 <TextSetting
                     settingName={t('settings.server.socks_proxy.label.host')}
                     value={serverSettings?.socksProxyHost}
                     handleChange={(proxyHost) => updateSetting('socksProxyHost', proxyHost)}
-                    disabled={!serverSettings?.socksProxyEnabled}
                 />
                 <TextSetting
                     settingName={t('settings.server.socks_proxy.label.port')}
                     value={serverSettings?.socksProxyPort}
                     handleChange={(proxyPort) => updateSetting('socksProxyPort', proxyPort)}
-                    disabled={!serverSettings?.socksProxyEnabled}
                 />
                 <TextSetting
                     settingName={t('settings.server.socks_proxy.label.username')}
                     value={serverSettings?.socksProxyUsername}
                     handleChange={(proxyUsername) => updateSetting('socksProxyUsername', proxyUsername)}
-                    disabled={!serverSettings?.socksProxyEnabled}
                 />
                 <TextSetting
                     settingName={t('settings.server.socks_proxy.label.password')}
                     value={serverSettings?.socksProxyPassword}
                     handleChange={(proxyPassword) => updateSetting('socksProxyPassword', proxyPassword)}
-                    disabled={!serverSettings?.socksProxyEnabled}
                     isPassword
                 />
             </List>
@@ -206,14 +201,12 @@ export const ServerSettings = () => {
                     settingName={t('settings.server.auth.basic.label.username')}
                     value={serverSettings?.basicAuthUsername}
                     handleChange={(authUsername) => updateSetting('basicAuthUsername', authUsername)}
-                    disabled={!serverSettings?.basicAuthEnabled}
                 />
                 <TextSetting
                     settingName={t('settings.server.auth.basic.label.password')}
                     value={serverSettings?.basicAuthPassword}
                     isPassword
                     handleChange={(authPassword) => updateSetting('basicAuthPassword', authPassword)}
-                    disabled={!serverSettings?.basicAuthEnabled}
                 />
             </List>
             <List


### PR DESCRIPTION
In case these settings were disabled, the other dependent settings were not editable. This prevented them from being set up as needed before enabling them

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->