### PR TITLE
Pass manga title into location state for migration search

### DIFF
--- a/src/components/manga/MangaGridCard.tsx
+++ b/src/components/manga/MangaGridCard.tsx
@@ -67,6 +67,7 @@ export const MangaGridCard = ({
             {...longPressBind(() => popupState.open(optionButtonRef.current))}
             onClick={handleClick}
             to={mangaLinkTo}
+            state={{ mangaTitle: title }}
             sx={{ textDecoration: 'none', touchCallout: 'none' }}
         >
             <Box

--- a/src/components/manga/MangaListCard.tsx
+++ b/src/components/manga/MangaListCard.tsx
@@ -44,6 +44,7 @@ export const MangaListCard = ({
             <CardActionArea
                 component={RouterLink}
                 to={mangaLinkTo}
+                state={{ mangaTitle: title }}
                 onClick={handleClick}
                 {...longPressBind(() => popupState.open(optionButtonRef.current))}
                 sx={{


### PR DESCRIPTION
In case the migration search was started by clicking on a manga card from the migration page the manga title was not passed to the search and thus was missing from the page title

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->