### PR TITLE
Prevent MUI Popper TypeError

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,6 +27,9 @@ export default defineConfig(() => ({
             '@': path.resolve(__dirname, './src'),
         },
     },
+    optimizeDeps: {
+        include: ['@mui/material/Tooltip'],
+    },
     plugins: [
         react(),
         viteTsconfigPaths(),


### PR DESCRIPTION
Vite chunking can cause "Uncaught TypeError: styled_default is not a function at Popper.js:14:20"

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->