### PR TITLE
Restore previous content type when clearing search

### DIFF
--- a/src/screens/SourceMangas.tsx
+++ b/src/screens/SourceMangas.tsx
@@ -246,14 +246,19 @@ export function SourceMangas() {
     );
     const [dialogFiltersToApply, setDialogFiltersToApply] = useState<IPos[]>(filtersToApply);
     const [resetScrollPosition, setResetScrollPosition] = useState(false);
-    const [contentType, setContentType] = useSessionStorage(
+    const [currentContentType, setCurrentContentType] = useSessionStorage<SourceContentType | undefined>(
+        `source-mangas-${sourceId}-content-type`,
+        initialContentType,
+    );
+    const [contentType, setLocationContentType] = useSessionStorage(
         `source-mangas-location-${locationKey}-${sourceId}-content-type`,
-        query ? SourceContentType.SEARCH : initialContentType,
+        query ? SourceContentType.SEARCH : currentContentType!,
     );
 
     useEffect(
         () => () => {
             setCurrentFiltersToApply(undefined);
+            setCurrentContentType(undefined);
         },
         [sourceId],
     );
@@ -261,6 +266,11 @@ export function SourceMangas() {
     const setFiltersToApply = (filters: IPos[]) => {
         setCurrentFiltersToApply(filters);
         setLocationFiltersToApply(filters);
+    };
+
+    const setContentType = (newContentType: SourceContentType) => {
+        setCurrentContentType(newContentType);
+        setLocationContentType(newContentType);
     };
 
     const [loadPage, { data, isLoading: loading, size: lastPageNum, abortRequest, filteredOutAllItemsOfFetchedPage }] =


### PR DESCRIPTION
After clearing the current search the initial content type was always restored instead of the previous selected content type

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->