### PR TITLE
only disable the update WebUI Settings on flavor === custom

### DIFF
--- a/src/screens/settings/WebUISettings.tsx
+++ b/src/screens/settings/WebUISettings.tsx
@@ -191,7 +191,7 @@ export const WebUISettings = () => {
     }
 
     const webUISettings = extractWebUISettings(data!.settings);
-    const isDefaultWebUI = webUISettings.webUIFlavor === WebUiFlavor.Webui;
+    const isCustomWebUI = webUISettings.webUIFlavor === WebUiFlavor.Custom;
 
     return (
         <List>
@@ -226,10 +226,10 @@ export const WebUISettings = () => {
                 value={webUISettings.webUIChannel}
                 values={CHANNEL_SELECT_VALUES}
                 handleChange={(channel) => updateSetting('webUIChannel', channel)}
-                disabled={!isDefaultWebUI}
+                disabled={isCustomWebUI}
             />
             <WebUIUpdateIntervalSetting
-                disabled={!isDefaultWebUI}
+                disabled={isCustomWebUI}
                 updateCheckInterval={webUISettings.webUIUpdateCheckInterval}
             />
             {!webUISettings.webUIUpdateCheckInterval && (


### PR DESCRIPTION
<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->

Currently if you change the flavor to VUI in webui it will disable some options that shouldn't be disabled as shown in image
![image](https://github.com/Suwayomi/Suwayomi-WebUI/assets/30987265/693013dd-65d9-4688-a0d4-60bc3300ff26)
those should only be disabled in the case of Custom as the options still function for VUI and any other future webui