### PR TITLE
Fix overflow on Continuous Horizontal view

### DIFF
--- a/src/components/reader/Page.tsx
+++ b/src/components/reader/Page.tsx
@@ -6,12 +6,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { CSSProperties, forwardRef } from 'react';
+import { CSSProperties, forwardRef, useCallback, useState } from 'react';
 import Box from '@mui/material/Box';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { IReaderSettings, ReaderType } from '@/typings';
 import { SpinnerImage } from '@/components/util/SpinnerImage';
+import { useResizeObserver } from '@/util/useResizeObserver';
 
 export const isHorizontalReaderType = (readerType: ReaderType): boolean =>
     ['ContinuesHorizontalLTR', 'ContinuesHorizontalRTL'].includes(readerType);
@@ -19,7 +20,11 @@ export const isHorizontalReaderType = (readerType: ReaderType): boolean =>
 export function imageStyle(settings: IReaderSettings): CSSProperties {
     const isVertical = settings.readerType === 'ContinuesVertical';
     const isHorizontal = isHorizontalReaderType(settings.readerType);
-    const scrollbarHeight = window.innerHeight - document.documentElement.clientHeight;
+    const [scrollbarHeight, setScrollbarHeight] = useState(0);
+    useResizeObserver(
+        document.documentElement,
+        useCallback(() => setScrollbarHeight(window.innerHeight - document.documentElement.clientHeight), []),
+    );
     const baseStyling: CSSProperties = {
         margin: 0,
         width: `${settings.readerWidth}%`,

--- a/src/components/reader/Page.tsx
+++ b/src/components/reader/Page.tsx
@@ -19,6 +19,7 @@ export const isHorizontalReaderType = (readerType: ReaderType): boolean =>
 export function imageStyle(settings: IReaderSettings): CSSProperties {
     const isVertical = settings.readerType === 'ContinuesVertical';
     const isHorizontal = isHorizontalReaderType(settings.readerType);
+    const scrollbarHeight = window.innerHeight - document.documentElement.clientHeight;
     const baseStyling: CSSProperties = {
         margin: 0,
         width: `${settings.readerWidth}%`,
@@ -31,8 +32,8 @@ export function imageStyle(settings: IReaderSettings): CSSProperties {
 
     const continuesHorizontalStyling: CSSProperties = {
         width: undefined,
-        minHeight: 'calc(100vh - 1rem)',
-        maxHeight: 'calc(100vh - 1rem)',
+        minHeight: `calc(100vh - ${scrollbarHeight}px)`,
+        maxHeight: `calc(100vh - ${scrollbarHeight}px)`,
         marginLeft: '7px',
         marginRight: '7px',
     };
@@ -42,8 +43,8 @@ export function imageStyle(settings: IReaderSettings): CSSProperties {
         height: undefined,
         minWidth: settings.scalePage ? 'calc(100vw - (100vw - 100%))' : undefined,
         maxWidth: 'calc(100vw - (100vw - 100%))',
-        minHeight: settings.scalePage ? 'calc(100vh - 1rem)' : undefined,
-        maxHeight: 'calc(100vh - 1rem)',
+        minHeight: settings.scalePage ? `calc(100vh - ${scrollbarHeight}px)` : undefined,
+        maxHeight: `calc(100vh - ${scrollbarHeight}px)`,
     };
 
     return {

--- a/src/components/reader/Page.tsx
+++ b/src/components/reader/Page.tsx
@@ -31,8 +31,8 @@ export function imageStyle(settings: IReaderSettings): CSSProperties {
 
     const continuesHorizontalStyling: CSSProperties = {
         width: undefined,
-        minHeight: '100vh',
-        maxHeight: '100vh',
+        minHeight: 'calc(100vh - 1rem)',
+        maxHeight: 'calc(100vh - 1rem)',
         marginLeft: '7px',
         marginRight: '7px',
     };
@@ -42,8 +42,8 @@ export function imageStyle(settings: IReaderSettings): CSSProperties {
         height: undefined,
         minWidth: settings.scalePage ? 'calc(100vw - (100vw - 100%))' : undefined,
         maxWidth: 'calc(100vw - (100vw - 100%))',
-        minHeight: settings.scalePage ? '100vh' : undefined,
-        maxHeight: '100vh',
+        minHeight: settings.scalePage ? 'calc(100vh - 1rem)' : undefined,
+        maxHeight: 'calc(100vh - 1rem)',
     };
 
     return {

--- a/src/screens/Reader.tsx
+++ b/src/screens/Reader.tsx
@@ -553,7 +553,7 @@ export function Reader() {
                 alignItems: 'center',
                 justifyContent: 'center',
                 minWidth: `calc((100vw - (100vw - 100%)) - ${navBarWidth}px)`, // 100vw = width excluding scrollbar; 100% = width including scrollbar
-                minHeight: '100vh',
+                minHeight: 'calc(100vh - 1rem)',
                 marginLeft: `${navBarWidth}px`,
             }}
         >

--- a/src/screens/Reader.tsx
+++ b/src/screens/Reader.tsx
@@ -42,6 +42,7 @@ import { GET_CHAPTERS_READER } from '@/lib/graphql/queries/ChapterQuery.ts';
 import { GET_MANGA_READER } from '@/lib/graphql/queries/MangaQuery.ts';
 import { TMangaReader } from '@/lib/data/Mangas.ts';
 import { CHAPTER_READER_FIELDS } from '@/lib/graphql/fragments/ChapterFragments.ts';
+import { useResizeObserver } from '@/util/useResizeObserver';
 
 type TChapter = GetChaptersReaderQuery['chapters']['nodes'][number];
 
@@ -487,6 +488,12 @@ export function Reader() {
         openNextChapter(ChapterOffset.PREV);
     }, [openNextChapter]);
 
+    const [scrollbarHeight, setScrollbarHeight] = useState(0);
+    useResizeObserver(
+        document.documentElement,
+        useCallback(() => setScrollbarHeight(window.innerHeight - document.documentElement.clientHeight), []),
+    );
+
     if (isLoading) {
         return (
             <Box
@@ -553,7 +560,7 @@ export function Reader() {
                 alignItems: 'center',
                 justifyContent: 'center',
                 minWidth: `calc((100vw - (100vw - 100%)) - ${navBarWidth}px)`, // 100vw = width excluding scrollbar; 100% = width including scrollbar
-                minHeight: 'calc(100vh - (100vh - 100%))',
+                minHeight: `calc((100vh - ${scrollbarHeight}px)`,
                 marginLeft: `${navBarWidth}px`,
             }}
         >

--- a/src/screens/Reader.tsx
+++ b/src/screens/Reader.tsx
@@ -553,7 +553,7 @@ export function Reader() {
                 alignItems: 'center',
                 justifyContent: 'center',
                 minWidth: `calc((100vw - (100vw - 100%)) - ${navBarWidth}px)`, // 100vw = width excluding scrollbar; 100% = width including scrollbar
-                minHeight: `calc(100vh - (100vh - 100%))`,
+                minHeight: 'calc(100vh - (100vh - 100%))',
                 marginLeft: `${navBarWidth}px`,
             }}
         >

--- a/src/screens/Reader.tsx
+++ b/src/screens/Reader.tsx
@@ -560,7 +560,7 @@ export function Reader() {
                 alignItems: 'center',
                 justifyContent: 'center',
                 minWidth: `calc((100vw - (100vw - 100%)) - ${navBarWidth}px)`, // 100vw = width excluding scrollbar; 100% = width including scrollbar
-                minHeight: `calc((100vh - ${scrollbarHeight}px)`,
+                minHeight: `calc(100vh - ${scrollbarHeight}px)`,
                 marginLeft: `${navBarWidth}px`,
             }}
         >

--- a/src/screens/Reader.tsx
+++ b/src/screens/Reader.tsx
@@ -553,7 +553,7 @@ export function Reader() {
                 alignItems: 'center',
                 justifyContent: 'center',
                 minWidth: `calc((100vw - (100vw - 100%)) - ${navBarWidth}px)`, // 100vw = width excluding scrollbar; 100% = width including scrollbar
-                minHeight: 'calc(100vh - 1rem)',
+                minHeight: `calc(100vh - (100vh - 100%))`,
                 marginLeft: `${navBarWidth}px`,
             }}
         >


### PR DESCRIPTION
<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->

Fixes a vertical overflow on the Continuous Horizontal View of the reader. Especially noticeable when the default font size is overridden on the browser (I use 20 instead of 16)

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/9748dfa9-de7a-49e5-95cd-bf5dc1ecc0c0) | ![image](https://github.com/user-attachments/assets/c42f8e93-2ff8-4902-bcc9-1cf534a0de94) |
| Vertical Overflow | No Vertical Overflow |