### PR TITLE
feat(spinnerImage): make image load more snappy, remove blank state

### DIFF
--- a/src/modules/core/components/SpinnerImage.tsx
+++ b/src/modules/core/components/SpinnerImage.tsx
@@ -38,7 +38,7 @@ export const SpinnerImage = forwardRef((props: IProps, imgRef: ForwardedRef<HTML
 
     const showMissingImageIcon = !src.length;
 
-    const [imageSourceUrl, setImageSourceUrl] = useState('');
+    const [imageSourceUrl, setImageSourceUrl] = useState(src);
     const [imgLoadRetryKey, setImgLoadRetryKey] = useState(0);
     const [isLoading, setIsLoading] = useState<boolean | undefined>(undefined);
     const [hasError, setHasError] = useState(false);


### PR DESCRIPTION
I noticed that there are blank state (couple miliseconds rendering) when changing pages (especially when using local source), this commit is to make the page navigation more snappy and seamless

before
![before](https://github.com/user-attachments/assets/2d2ccc0e-99a8-4175-baa0-c186ba7263f8)


after
![after](https://github.com/user-attachments/assets/4a49f176-32f0-482e-bd3d-ef448f52d9e5)
