### PR TITLE
fix reader chapter transition warning chapters number off by 1

### DIFF
--- a/src/modules/reader/services/ReaderControls.ts
+++ b/src/modules/reader/services/ReaderControls.ts
@@ -219,7 +219,7 @@ export class ReaderControls {
         const continuousChapter = isContinuousChapter
             ? ''
             : t(offsetToTranslationKeys[offset].chapter_number, {
-                  count: missingChapters,
+                  count: missingChapters - 1,
                   nextChapter: `#${chapterToOpen.chapterNumber} ${chapterToOpen.name}`,
                   currentChapter: `#${currentChapter.chapterNumber} ${currentChapter.name}`,
               });


### PR DESCRIPTION
was previously 

![image](https://github.com/user-attachments/assets/869f2332-5795-4c54-ac08-49c960e884f7)
this should make that say ``There are 1 missing chapters.``