### PR TITLE
Update manifest link to support HTTP basic auth

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="manifest" href="/site.webmanifest" crossorigin="use-credentials" />
 </head>
 <body>
 <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->

When HTTP Basic Auth is enabled, the WebUI cannot be installed as a PWA because browsers do not include credentials by default when fetching the web manifest.

This PR adds `crossorigin="use-credentials"` to the web manifest link in `index.html`, allowing the browser to fetch the manifest using HTTP Basic Auth credentials, enabling PWA functionality.

A similar implementation in VUI: https://github.com/Suwayomi/Suwayomi-VUI/blob/43bd5f760f16d5fc7089196b0a072bccba5bb3cf/src/app.html#L17