### PR TITLE
Support non-Latin characters in library search function

### DIFF
--- a/src/util/Strings.ts
+++ b/src/util/Strings.ts
@@ -10,7 +10,8 @@ export const baseCleanup = (str: string) => str.toLowerCase().trim();
 
 export const enhancedCleanup = (str: string): string =>
     baseCleanup(str)
-        .replace(/[^a-zA-Z0-9\\s]+/g, ' ')
+        .normalize('NFKC')
+        .replace(/[^\p{L}\p{N}\s]+/gu, ' ')
         .trim();
 
 export const reverseString = (str: string, separator: string = ''): string =>

--- a/src/util/Strings.ts
+++ b/src/util/Strings.ts
@@ -11,7 +11,7 @@ export const baseCleanup = (str: string) => str.toLowerCase().trim();
 export const enhancedCleanup = (str: string): string =>
     baseCleanup(str)
         .normalize('NFKC')
-        .replace(/[^\p{L}\p{N}\s]+/gu, ' ')
+        .replace(/[^\p{L}\p{N}]+/gu, ' ')
         .trim();
 
 export const reverseString = (str: string, separator: string = ''): string =>


### PR DESCRIPTION
### What does this PR do?

This PR updates the enhancedCleanup function to properly handle non-Latin characters (e.g., Japanese, Chinese) by:
- Using a Unicode regex (\p{L}\p{N}\s) to ensure multilingual support while still removing unnecessary symbols/punctuations to keep text clean for search.
- Applying Unicode NFKC normalization to unify full-width and half-width character variations.

### Why is this needed?

The previous implementation (replace(/[^a-zA-Z0-9\\s]+/g, ' ')) removed all non-Latin characters, preventing proper search functionality for titles written in languages other than English.
Now, users can search for titles more flexibly, even if they contain diacritics, full-width characters, or non-Latin scripts.

### Example
| Input | Old Output | New Output |
| ----- | ----------- | ------------ |
| "ＡＢＣ123" | "123" | "abc123" |
| "製品-123!" | "123" | "製品 123" |
| "Café Latte" | "caf latte" | "café latte" |
| "カフェ・ラテ" | "" | "カフェ ラテ" |

