### PR TITLE
Reader: Reset bounds on window size change

### DIFF
--- a/src/modules/reader/components/viewer/ReaderChapterViewer.tsx
+++ b/src/modules/reader/components/viewer/ReaderChapterViewer.tsx
@@ -153,6 +153,7 @@ const BaseReaderChapterViewer = ({
     const isCurrentChapterRef = useRef(isCurrentChapter);
     const imageRefs = useRef<(HTMLElement | null)[]>(pages.map(() => null));
     const pagerRef = useRef<HTMLDivElement>(null);
+    const readerNavBarWidthRef = useRef<number>(readerNavBarWidth);
 
     const actualPages = useMemo(() => {
         const arePagesLoaded = !!totalPages;
@@ -261,6 +262,13 @@ const BaseReaderChapterViewer = ({
         window.addEventListener('resize', f);
         return () => window.removeEventListener('resize', f);
     }, [onSizeReset, ref.current]);
+
+    useEffect(() => {
+        if (readerNavBarWidthRef.current === readerNavBarWidth) return;
+        // setting to 0x0 resets the entire state, so on next render the resize observer will re-init with the correct size
+        onSizeReset(0, 0);
+        readerNavBarWidthRef.current = readerNavBarWidth;
+    }, [onSizeReset, readerNavBarWidth]);
 
     const updateState = <T,>(
         value: T,

--- a/src/modules/reader/components/viewer/ReaderChapterViewer.tsx
+++ b/src/modules/reader/components/viewer/ReaderChapterViewer.tsx
@@ -89,6 +89,7 @@ const BaseReaderChapterViewer = ({
     scrollbarYSize,
     readerNavBarWidth,
     onSizeChange,
+    onSizeReset,
     minWidth,
     minHeight,
 }: Pick<
@@ -126,6 +127,7 @@ const BaseReaderChapterViewer = ({
         scrollIntoView: boolean;
         resumeMode: ReaderResumeMode;
         onSizeChange: (width: number, height: number) => void;
+        onSizeReset: (width: number, height: number) => void;
         minWidth: number;
         minHeight: number;
     }) => {
@@ -248,6 +250,17 @@ const BaseReaderChapterViewer = ({
             [onSizeChange, ref.current],
         ),
     );
+
+    useEffect(() => {
+        const f = () => {
+            if (!ref.current || !ref.current.parentElement) return;
+            const { clientWidth, clientHeight } = ref.current.parentElement;
+            onSizeReset(clientWidth, clientHeight);
+        };
+
+        window.addEventListener('resize', f);
+        return () => window.removeEventListener('resize', f);
+    }, [onSizeReset, ref.current]);
 
     const updateState = <T,>(
         value: T,

--- a/src/modules/reader/components/viewer/ReaderViewer.tsx
+++ b/src/modules/reader/components/viewer/ReaderViewer.tsx
@@ -231,6 +231,7 @@ const BaseReaderViewer = forwardRef(
             chapterViewerSize.current.minChapterViewWidth = width;
             chapterViewerSize.current.minChapterViewHeight = height;
             setTriggerReRender({});
+            setPageToScrollToIndex(currentPageIndex);
         };
 
         useReaderHandlePageSelection(

--- a/src/modules/reader/components/viewer/ReaderViewer.tsx
+++ b/src/modules/reader/components/viewer/ReaderViewer.tsx
@@ -227,6 +227,12 @@ const BaseReaderViewer = forwardRef(
             [isContinuousReadingModeActive, isContinuousVerticalReadingModeActive],
         );
 
+        const onChapterViewSizeReset = (width: number, height: number) => {
+            chapterViewerSize.current.minChapterViewWidth = width;
+            chapterViewerSize.current.minChapterViewHeight = height;
+            setTriggerReRender({});
+        };
+
         useReaderHandlePageSelection(
             pageToScrollToIndex,
             currentPageIndex,
@@ -397,6 +403,7 @@ const BaseReaderViewer = forwardRef(
                             scrollbarYSize={scrollbarYSize}
                             readerNavBarWidth={readerNavBarWidth}
                             onSizeChange={onChapterViewSizeChange}
+                            onSizeReset={onChapterViewSizeReset}
                             minWidth={minChapterViewWidth}
                             minHeight={minChapterViewHeight}
                         />


### PR DESCRIPTION
This attempts to handle page resizing a little better than previously (ref 19f2d99).

It's not perfect, but not changing position at all seems impossible due
to how resizes are handled by the browser (since we adjust our content
to the window size).

Partially addresses #902 