### PR TITLE
Reader: Re-scroll on reader mode change

### DIFF
--- a/src/modules/reader/components/viewer/ReaderViewer.tsx
+++ b/src/modules/reader/components/viewer/ReaderViewer.tsx
@@ -271,6 +271,17 @@ const BaseReaderViewer = forwardRef(
             setTriggerReRender({});
         }, [readingMode]);
 
+        useEffect(() => {
+            setReaderStateChapters((prevState) => ({
+                ...prevState,
+                visibleChapters: {
+                    ...prevState.visibleChapters,
+                    scrollIntoView: true,
+                },
+            }));
+            setPageToScrollToIndex(currentPageIndex);
+        }, [readingMode]);
+
         if (!initialChapter || !currentChapter) {
             throw new Error('ReaderViewer: illegal state - initialChapter and currentChapter should not be undefined');
         }

--- a/src/modules/reader/components/viewer/ReaderViewer.tsx
+++ b/src/modules/reader/components/viewer/ReaderViewer.tsx
@@ -260,19 +260,18 @@ const BaseReaderViewer = forwardRef(
             scrollElementRef,
             currentChapter?.id,
             currentChapterIndex,
+            currentPageIndex,
             chaptersToRender,
             visibleChapters,
+            readingMode,
             isContinuousReadingModeActive,
             readingDirection,
+            setPageToScrollToIndex,
         );
 
         useLayoutEffect(() => {
             chapterViewerSize.current = { minChapterViewWidth: 0, minChapterViewHeight: 0 };
             setTriggerReRender({});
-        }, [readingMode]);
-
-        useLayoutEffect(() => {
-            setPageToScrollToIndex(currentPageIndex);
         }, [readingMode]);
 
         if (!initialChapter || !currentChapter) {

--- a/src/modules/reader/components/viewer/ReaderViewer.tsx
+++ b/src/modules/reader/components/viewer/ReaderViewer.tsx
@@ -271,14 +271,7 @@ const BaseReaderViewer = forwardRef(
             setTriggerReRender({});
         }, [readingMode]);
 
-        useEffect(() => {
-            setReaderStateChapters((prevState) => ({
-                ...prevState,
-                visibleChapters: {
-                    ...prevState.visibleChapters,
-                    scrollIntoView: true,
-                },
-            }));
+        useLayoutEffect(() => {
             setPageToScrollToIndex(currentPageIndex);
         }, [readingMode]);
 

--- a/src/modules/reader/hooks/useReaderPreserveScrollPosition.ts
+++ b/src/modules/reader/hooks/useReaderPreserveScrollPosition.ts
@@ -8,20 +8,24 @@
 
 import { RefObject, useEffect, useLayoutEffect, useRef } from 'react';
 import { ChapterIdInfo } from '@/modules/chapter/services/Chapters.ts';
-import { ReaderStateChapters, ReadingDirection } from '@/modules/reader/types/Reader.types.ts';
+import { ReaderStateChapters, ReadingDirection, ReadingMode } from '@/modules/reader/types/Reader.types.ts';
 import { getOptionForDirection } from '@/modules/theme/services/ThemeCreator.ts';
 import { READING_DIRECTION_TO_THEME_DIRECTION } from '@/modules/reader/constants/ReaderSettings.constants.tsx';
 import { getPreviousNextChapterVisibility } from '@/modules/reader/utils/Reader.utils.ts';
 import { TChapterReader } from '@/modules/chapter/Chapter.types.ts';
+import { ReaderStatePages } from '@/modules/reader/types/ReaderProgressBar.types';
 
 export const useReaderPreserveScrollPosition = (
     scrollElementRef: RefObject<HTMLElement | null>,
     currentChapterId: ChapterIdInfo['id'] | undefined,
     chapterIndex: number,
+    currentPageIndex: number,
     chaptersToRender: TChapterReader[],
     visibleChapters: ReaderStateChapters['visibleChapters'],
+    readingMode: ReadingMode,
     isContinuousReadingModeActive: boolean,
     readingDirection: ReadingDirection,
+    setPageToScrollToIndex: ReaderStatePages['setPageToScrollToIndex'],
 ) => {
     const scrollPosition = useRef({ left: 0, top: 0, scrollWidth: 0, scrollHeight: 0 });
 
@@ -91,4 +95,8 @@ export const useReaderPreserveScrollPosition = (
 
         scrollElement.scrollTo(newLeft, newTop);
     }, [currentChapterId]);
+
+    useLayoutEffect(() => {
+        setPageToScrollToIndex(currentPageIndex);
+    }, [readingMode]);
 };


### PR DESCRIPTION
Before:
https://github.com/user-attachments/assets/8c967c40-3847-46b2-b81d-3f316d543988

When changing from paged modes to continuous modes, the reader would completely lose position. While not obvious in the video, scrolling to a page would show that the reader has forgotten where it is; the page loading indicator is shown indefinitely. The user could fix the situation by manually switching chapter or page using the controls. This is now done automatically, though it's not perfect, since some modes are lossy when converting state.

Partially addresses #902