### PR TITLE
Fixes two places where navbar was not considered

### DIFF
--- a/src/modules/reader/components/viewer/ReaderTransitionPage.tsx
+++ b/src/modules/reader/components/viewer/ReaderTransitionPage.tsx
@@ -147,8 +147,11 @@ const BaseReaderTransitionPage = ({
                         ...applyStyles(!isFitWidthPageScaleMode, { alignItems: 'baseline' }),
                     }),
                     ...applyStyles(readingMode === ReadingMode.CONTINUOUS_HORIZONTAL, {
+                        flexDirection: 'row',
+                        maxHeight: `calc(100vh - ${scrollbarXSize}px)`,
+                        position: 'sticky',
+                        top: 0,
                         minWidth: `calc(100vw - ${scrollbarYSize}px - ${readerNavBarWidth}px)`,
-                        justifyContent: 'unset',
                     }),
                 }),
             }}
@@ -158,25 +161,12 @@ const BaseReaderTransitionPage = ({
                     gap: 2,
                     maxWidth: (theme) =>
                         // spacing = added padding left + right
-                        `calc(100vw - ${scrollbarYSize}px - ${readerNavBarWidth}px - ${theme.spacing(2)}px)`,
+                        `calc(100vw - ${scrollbarYSize}px - ${readerNavBarWidth}px - ${theme.spacing(2)})`,
                     maxHeight: `calc(100vh - ${scrollbarXSize}px)`,
                     width: 'max-content',
                     p: 1,
                     ...applyStyles(isContinuousReadingMode(readingMode), {
-                        ...applyStyles(
-                            // on small screens with "fit to with" enabled, "left 50%" does not center the element in the
-                            // viewport which then causes "translate" to move the element mostly outside the viewport with
-                            // only a small part of it being visible
-                            !isFitWidthPageScaleMode && isContinuousVerticalReadingMode(readingMode),
-                            {
-                                alignSelf: 'center',
-                            },
-                        ),
-                        ...applyStyles(readingMode === ReadingMode.CONTINUOUS_HORIZONTAL, {
-                            position: 'sticky',
-                            top: '50%',
-                            transform: 'translateY(-50%)',
-                        }),
+                        alignSelf: 'center',
                     }),
                 }}
             >

--- a/src/modules/reader/components/viewer/ReaderTransitionPage.tsx
+++ b/src/modules/reader/components/viewer/ReaderTransitionPage.tsx
@@ -156,7 +156,9 @@ const BaseReaderTransitionPage = ({
             <Stack
                 sx={{
                     gap: 2,
-                    maxWidth: `calc(100vw - ${scrollbarYSize}px - ${readerNavBarWidth}px - 16px)`,
+                    maxWidth: (theme) =>
+                        // spacing = added padding left + right
+                        `calc(100vw - ${scrollbarYSize}px - ${readerNavBarWidth}px - ${theme.spacing(2)}px)`,
                     maxHeight: `calc(100vh - ${scrollbarXSize}px)`,
                     width: 'max-content',
                     p: 1,

--- a/src/modules/reader/components/viewer/ReaderTransitionPage.tsx
+++ b/src/modules/reader/components/viewer/ReaderTransitionPage.tsx
@@ -140,6 +140,9 @@ const BaseReaderTransitionPage = ({
                     position: 'relative',
                     transform: 'scale(1)',
                     ...applyStyles(isContinuousVerticalReadingMode(readingMode), {
+                        maxWidth: `calc(100vw - ${scrollbarYSize}px - ${readerNavBarWidth}px)`,
+                        position: 'sticky',
+                        left: 0,
                         minHeight: `calc(100vh - ${scrollbarXSize}px)`,
                         ...applyStyles(!isFitWidthPageScaleMode, { alignItems: 'baseline' }),
                     }),
@@ -158,7 +161,6 @@ const BaseReaderTransitionPage = ({
                     width: 'max-content',
                     p: 1,
                     ...applyStyles(isContinuousReadingMode(readingMode), {
-                        position: 'sticky',
                         ...applyStyles(
                             // on small screens with "fit to with" enabled, "left 50%" does not center the element in the
                             // viewport which then causes "translate" to move the element mostly outside the viewport with
@@ -169,6 +171,7 @@ const BaseReaderTransitionPage = ({
                             },
                         ),
                         ...applyStyles(readingMode === ReadingMode.CONTINUOUS_HORIZONTAL, {
+                            position: 'sticky',
                             top: '50%',
                             transform: 'translateY(-50%)',
                         }),

--- a/src/modules/reader/components/viewer/ReaderTransitionPage.tsx
+++ b/src/modules/reader/components/viewer/ReaderTransitionPage.tsx
@@ -153,7 +153,7 @@ const BaseReaderTransitionPage = ({
             <Stack
                 sx={{
                     gap: 2,
-                    maxWidth: `calc(100vw - ${scrollbarYSize}px)`,
+                    maxWidth: `calc(100vw - ${scrollbarYSize}px - ${readerNavBarWidth}px - 16px)`,
                     maxHeight: `calc(100vh - ${scrollbarXSize}px)`,
                     width: 'max-content',
                     p: 1,
@@ -165,8 +165,7 @@ const BaseReaderTransitionPage = ({
                             // only a small part of it being visible
                             !isFitWidthPageScaleMode && isContinuousVerticalReadingMode(readingMode),
                             {
-                                left: '50%',
-                                transform: 'translateX(-50%)',
+                                alignSelf: 'center',
                             },
                         ),
                         ...applyStyles(readingMode === ReadingMode.CONTINUOUS_HORIZONTAL, {

--- a/src/modules/reader/utils/ReaderPager.utils.tsx
+++ b/src/modules/reader/utils/ReaderPager.utils.tsx
@@ -72,13 +72,7 @@ export const getImagePlaceholderStyling = (
 ): CSSObject => {
     const OVER_9000 = 9000;
 
-    const getMaxWidth = (width: string) => {
-        if (width === '100vw') {
-            return `calc(${width} - ${widthOffset}px)`;
-        }
-
-        return width;
-    };
+    const getMaxWidth = (width: string) => `calc(${width} - ${widthOffset}px)`;
     const getDesktopWidth = (width: number, readerWidthValue?: number) =>
         getMaxWidth(`${coerceIn(readerWidthValue ?? width, Math.min(width, readerWidthValue ?? OVER_9000), width)}vw`);
 


### PR DESCRIPTION
When set to static, the navbar consumes space, so `vw` units are not enough.
On small screens, the `left`+`transform` approach does not work nicely, so just use standard flex alignment, the container is already a flexbox.

As mentioned on #905