### PR TITLE
Make category setting subheading translatable

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -35,7 +35,8 @@
       "category_one": "Category",
       "category_other": "Categories",
       "set_categories": "Set categories"
-    }
+    },
+    "value": "{{count}} $t(category.title.category, lowercase)"
   },
   "chapter": {
     "action": {

--- a/src/modules/library/screens/LibrarySettings.tsx
+++ b/src/modules/library/screens/LibrarySettings.tsx
@@ -137,10 +137,7 @@ export function LibrarySettings() {
                 <ListItemLink to={AppRoutes.settings.childRoutes.categories.path}>
                     <ListItemText
                         primary={t('category.dialog.title.edit_category_other')}
-                        secondary={t('global.value', {
-                            value: categoryCount,
-                            unit: ` ${t('category.title.category', { count: categoryCount })}`.toLocaleLowerCase(),
-                        })}
+                        secondary={t('category.value', { count: categoryCount })}
                     />
                 </ListItemLink>
                 <ListItem>


### PR DESCRIPTION
The `.toLocalLowerCase` is english-specific, this should be handled via a dedicated translation like everywhere else, `global.value` is being abused here