### PR TITLE
Update scroll preserve by tracking cursor

### DIFF
--- a/src/modules/reader/components/viewer/ReaderViewer.tsx
+++ b/src/modules/reader/components/viewer/ReaderViewer.tsx
@@ -282,14 +282,9 @@ const BaseReaderViewer = forwardRef(
         useReaderAutoScroll(isOverlayVisible, automaticScrolling);
         useReaderPreserveScrollPosition(
             scrollElementRef,
-            currentChapter?.id,
-            currentChapterIndex,
             currentPageIndex,
-            chaptersToRender,
-            visibleChapters,
             readingMode,
             isContinuousReadingModeActive,
-            readingDirection,
             readerNavBarWidth,
             setPageToScrollToIndex,
             pageScaleMode,

--- a/src/modules/reader/hooks/useReaderPreserveScrollPosition.ts
+++ b/src/modules/reader/hooks/useReaderPreserveScrollPosition.ts
@@ -7,14 +7,7 @@
  */
 
 import { RefObject, useCallback, useEffect, useLayoutEffect, useRef } from 'react';
-import { ChapterIdInfo } from '@/modules/chapter/services/Chapters.ts';
-import {
-    ReaderPageScaleMode,
-    ReaderStateChapters,
-    ReadingDirection,
-    ReadingMode,
-} from '@/modules/reader/types/Reader.types.ts';
-import { TChapterReader } from '@/modules/chapter/Chapter.types.ts';
+import { ReaderPageScaleMode, ReadingMode } from '@/modules/reader/types/Reader.types.ts';
 import { ReaderStatePages } from '@/modules/reader/types/ReaderProgressBar.types';
 import { isReaderWidthEditable } from '@/modules/reader/utils/ReaderSettings.utils.tsx';
 
@@ -35,14 +28,9 @@ const getActiveScrollElement = (root: HTMLElement): HTMLElement | undefined => {
 
 export const useReaderPreserveScrollPosition = (
     scrollElementRef: RefObject<HTMLElement | null>,
-    currentChapterId: ChapterIdInfo['id'] | undefined,
-    chapterIndex: number,
     pageIndex: number,
-    chaptersToRender: TChapterReader[],
-    visibleChapters: ReaderStateChapters['visibleChapters'],
     readingMode: ReadingMode,
     isContinuousReadingModeActive: boolean,
-    readingDirection: ReadingDirection,
     readerNavBarWidth: number,
     setPageToScrollToIndex: ReaderStatePages['setPageToScrollToIndex'],
     pageScaleMode: ReaderPageScaleMode,

--- a/src/modules/reader/hooks/useReaderPreserveScrollPosition.ts
+++ b/src/modules/reader/hooks/useReaderPreserveScrollPosition.ts
@@ -96,16 +96,12 @@ export const useReaderPreserveScrollPosition = (
             for (const entry of entries) {
                 for (const added of entry.addedNodes) {
                     if (added instanceof HTMLElement) {
-                        for (const img of added.querySelectorAll('img')) {
-                            resizeObserver.observe(img);
-                        }
+                        resizeObserver.observe(added);
                     }
                 }
                 for (const removed of entry.removedNodes) {
                     if (removed instanceof HTMLElement) {
-                        for (const img of removed.querySelectorAll('img')) {
-                            resizeObserver.unobserve(img);
-                        }
+                        resizeObserver.unobserve(removed);
                     }
                 }
             }


### PR DESCRIPTION
Closes #912

This PR tracks which element was (roughly) in focus by the user depending on scroll position. Then when elements are added, it attempts to scroll back to the old position by using the new position of the focused element. In effect, this allows to more closely estimate if new content was added in front or behind the current reading position.

This is not perfect. The video below shows what happens most of the time; scroll position is reset to where it should be. Sometimes, the user instead ends up on the last or second to last page, not sure why that happens (possibly different order of image loads?)


https://github.com/user-attachments/assets/7cccb707-10db-4c1d-92aa-5767de58b670

Tested in all reading modes. I have not seen any bad side effects in other situations; it does help a bit with forward scrolling during load, but not as much as in this situation.