### PR TITLE
Add author/artist sorting and search functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/*
 tools/scripts/tokens.json
 
 src/lib/graphql/schema.json
+pnpm-lock.yaml

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -10,7 +10,8 @@
                     "by_date_added": "Kürzlich hinzugefügt",
                     "by_latest_uploaded_chapter": "Zuletzt hochgeladenes Kapitel",
                     "by_latest_fetched_chapter": "Zuletzt abgerufenes Kapitel",
-                    "by_total_chapters": "Gesamte Anzahl der Kapitel"
+                    "by_total_chapters": "Gesamte Anzahl der Kapitel",
+                    "by_artist_or_author": "Nach Künstler/Autor"
                 }
             },
             "display": {

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -602,7 +602,8 @@
           "by_latest_fetched_chapter": "Latest fetched chapter",
           "by_latest_uploaded_chapter": "Latest uploaded chapter",
           "by_total_chapters": "Total chapters",
-          "by_unread_chapters": "Unread chapters"
+          "by_unread_chapters": "Unread chapters",
+          "by_artist_or_author": "By artist/author"
         }
       }
     },

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -434,7 +434,8 @@
                     "by_date_added": "Añadido recientemente",
                     "by_latest_fetched_chapter": "Capítulo más reciente",
                     "by_latest_uploaded_chapter": "Último capítulo subido",
-                    "by_total_chapters": "Capítulos totales"
+                    "by_total_chapters": "Capítulos totales",
+                    "by_artist_or_author": "Por artista/autor"
                 }
             },
             "display": {

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -10,7 +10,8 @@
                     "by_date_added": "Par date d'ajout",
                     "by_latest_uploaded_chapter": "Dernier chapitre mis en ligne",
                     "by_latest_fetched_chapter": "Dernier chapitre récupéré",
-                    "by_total_chapters": "Nombre total de chapitres"
+                    "by_total_chapters": "Nombre total de chapitres",
+                    "by_artist_or_author": "Par artiste/auteur"
                 }
             },
             "display": {

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -479,7 +479,8 @@
                 "by_source": "Dalla fonte",
                 "by_fetch_date": "Per data di recupero",
                 "by_chapter_number": "Per numero capitolo",
-                "by_upload_date": "Per data di caricamento"
+                "by_upload_date": "Per data di caricamento",
+                "by_artist_or_author": "Per artista/autore"
             }
         },
         "time": {
@@ -1133,7 +1134,8 @@
                     "by_latest_uploaded_chapter": "Ultimo capitolo caricato",
                     "by_latest_fetched_chapter": "Ultimo capitolo recuperato",
                     "alphabetically": "A-Z",
-                    "by_date_added": "Aggiunto di recente"
+                    "by_date_added": "Aggiunto di recente",
+                    "by_artist_or_author": "Per artista/autore"
                 }
             }
         },

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -457,7 +457,8 @@
                     "alphabetically": "A-Z",
                     "by_latest_fetched_chapter": "最近追加された章",
                     "by_last_read": "最近読んだ",
-                    "by_unread_chapters": "未読の章"
+                    "by_unread_chapters": "未読の章",
+                    "by_artist_or_author": "作者/アーティスト順"
                 }
             },
             "display": {

--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -603,7 +603,8 @@
                     "by_date_added": "Ostatnio dodane",
                     "by_unread_chapters": "Nieprzeczytane rozdziały",
                     "by_latest_fetched_chapter": "Ostatnio pobrany rozdział",
-                    "by_total_chapters": "Łączna liczba rozdziałów"
+                    "by_total_chapters": "Łączna liczba rozdziałów",
+                    "by_artist_or_author": "Według artysty/autora"
                 }
             }
         },

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -416,7 +416,8 @@
                 "by_upload_date": "Por data do envio",
                 "by_chapter_number": "Pelo número do capítulo",
                 "asc": "Ascendente",
-                "desc": "Descendente"
+                "desc": "Descendente",
+                "by_artist_or_author": "Por artista/autor"
             }
         },
         "time": {
@@ -1139,7 +1140,8 @@
                     "by_unread_chapters": "Capítulos não lidos",
                     "by_latest_uploaded_chapter": "Último capítulo carregado",
                     "by_date_added": "Adicionados recentemente",
-                    "by_total_chapters": "Capítulos totais"
+                    "by_total_chapters": "Capítulos totais",
+                    "by_artist_or_author": "Por artista/autor"
                 }
             }
         },

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -362,7 +362,8 @@
                     "alphabetically": "А-Я",
                     "by_date_added": "Недавно добавленные",
                     "by_latest_uploaded_chapter": "Последняя загруженная глава",
-                    "by_total_chapters": "Всего глав"
+                    "by_total_chapters": "Всего глав",
+                    "by_artist_or_author": "По художнику/автору"
                 }
             },
             "display": {

--- a/public/locales/tr.json
+++ b/public/locales/tr.json
@@ -514,7 +514,8 @@
                     "by_last_read": "Son zamanlarda okunanlar",
                     "by_latest_uploaded_chapter": "Son yüklenen bölüm",
                     "by_latest_fetched_chapter": "Son getirilen bölüm",
-                    "by_total_chapters": "Toplam bölüm sayısı"
+                    "by_total_chapters": "Toplam bölüm sayısı",
+                    "by_artist_or_author": "Sanatçı/yazar göre"
                 }
             }
         },

--- a/public/locales/uk.json
+++ b/public/locales/uk.json
@@ -486,7 +486,8 @@
                     "by_unread_chapters": "Непрочитані глави",
                     "by_last_read": "Нещодавно прочитане",
                     "by_latest_uploaded_chapter": "Остання завантажена глава",
-                    "by_latest_fetched_chapter": "Остання завантажена глава"
+                    "by_latest_fetched_chapter": "Остання завантажена глава",
+                    "by_artist_or_author": "За художником/автором"
                 }
             }
         },

--- a/public/locales/vi.json
+++ b/public/locales/vi.json
@@ -537,7 +537,8 @@
                     "by_last_read": "Đọc gần đây",
                     "by_latest_uploaded_chapter": "Chương mới tải lên",
                     "by_latest_fetched_chapter": "Chương mới nhất",
-                    "by_total_chapters": "Tổng số chương"
+                    "by_total_chapters": "Tổng số chương",
+                    "by_artist_or_author": "Theo tác giả/họa sĩ"
                 }
             }
         },

--- a/public/locales/zh_Hans.json
+++ b/public/locales/zh_Hans.json
@@ -454,6 +454,7 @@
                 "by_fetch_date": "按日期",
                 "by_chapter_number": "按章节序号",
                 "by_upload_date": "按上传日期",
+                "by_artist_or_author": "按作者/画师",
                 "asc": "升序",
                 "desc": "降序"
             }
@@ -538,7 +539,8 @@
                     "alphabetically": "按字母顺序",
                     "by_latest_fetched_chapter": "最新获取的章节",
                     "by_latest_uploaded_chapter": "最新上传的章节",
-                    "by_total_chapters": "总章节数"
+                    "by_total_chapters": "总章节数",
+                    "by_artist_or_author": "按作者/画师"
                 }
             }
         },

--- a/public/locales/zh_Hant.json
+++ b/public/locales/zh_Hant.json
@@ -522,7 +522,8 @@
                 "by_upload_date": "依照更新日期",
                 "by_chapter_number": "依照章節編號",
                 "asc": "升序",
-                "desc": "降序"
+                "desc": "降序",
+                "by_artist_or_author": "依照作者/畫師"
             }
         },
         "error": {

--- a/src/modules/library/Library.types.ts
+++ b/src/modules/library/Library.types.ts
@@ -27,7 +27,8 @@ export type LibrarySortMode =
     | 'dateAdded'
     | 'lastRead'
     | 'latestFetchedChapter'
-    | 'latestUploadedChapter';
+    | 'latestUploadedChapter'
+    | 'byArtistOrAuthor';
 
 export interface LibraryOptions {
     // sort options

--- a/src/modules/library/components/LibraryOptionsPanel.tsx
+++ b/src/modules/library/components/LibraryOptionsPanel.tsx
@@ -46,6 +46,7 @@ const SORT_OPTIONS: [LibrarySortMode, TranslationKey][] = [
     ['lastRead', 'library.option.sort.label.by_last_read'],
     ['latestFetchedChapter', 'library.option.sort.label.by_latest_fetched_chapter'],
     ['latestUploadedChapter', 'library.option.sort.label.by_latest_uploaded_chapter'],
+    ['byArtistOrAuthor', 'library.option.sort.label.by_artist_or_author'],
 ];
 
 export const LibraryOptionsPanel = ({

--- a/src/modules/library/hooks/useGetVisibleLibraryMangas.ts
+++ b/src/modules/library/hooks/useGetVisibleLibraryMangas.ts
@@ -156,6 +156,14 @@ const sortByNumber = (a: number | string = 0, b: number | string = 0) => Number(
 
 const sortByString = (a: string, b: string): number => a.localeCompare(b);
 
+const getFirstArtist = (artistString: string): string => {
+    if (!artistString || artistString === 'Unknown') return 'Unknown';
+    // Handle multiple delimiters (, |, 、etc)
+    const artists = artistString.split(/\s*[,|、]\s*/);
+    // Return the first artist name and trim whitespace
+    return artists[0].trim();
+};
+
 type TMangaSort = Pick<MangaType, 'title' | 'inLibraryAt' | 'unreadCount'> &
     MangaChapterCountInfo & {
         lastReadChapter?: Pick<ChapterType, 'lastReadAt'> | null;
@@ -192,6 +200,43 @@ const sortManga = <Manga extends TMangaSort>(
             break;
         case 'totalChapters':
             result.sort((a, b) => sortByNumber(a.chapters.totalCount, b.chapters.totalCount));
+            break;
+        case 'byArtistOrAuthor':
+            result.sort((a, b) => {
+                const aArtist = getFirstArtist(a.artist || 'Unknown');
+                const bArtist = getFirstArtist(b.artist || 'Unknown');
+                const aAuthor = getFirstArtist(a.author || 'Unknown');
+                const bAuthor = getFirstArtist(b.author || 'Unknown');
+
+                // If both have artists, sort by artist first
+                if (aArtist !== 'Unknown' && bArtist !== 'Unknown') {
+                    return sortByString(aArtist, bArtist);
+                }
+                
+                // If one has artist and the other doesn't, the one with artist comes first
+                if (aArtist !== 'Unknown' && bArtist === 'Unknown') {
+                    return -1;
+                }
+                if (aArtist === 'Unknown' && bArtist !== 'Unknown') {
+                    return 1;
+                }
+
+                // If neither has artist, sort by author
+                if (aAuthor !== 'Unknown' && bAuthor !== 'Unknown') {
+                    return sortByString(aAuthor, bAuthor);
+                }
+
+                // If one has author and the other doesn't, the one with author comes first
+                if (aAuthor !== 'Unknown' && bAuthor === 'Unknown') {
+                    return -1;
+                }
+                if (aAuthor === 'Unknown' && bAuthor !== 'Unknown') {
+                    return 1;
+                }
+
+                // If neither has artist or author, sort by title
+                return sortByString(a.title, b.title);
+            });
             break;
         default:
             break;

--- a/src/modules/manga/components/ClickableMetadata.tsx
+++ b/src/modules/manga/components/ClickableMetadata.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { useNavigate } from 'react-router-dom';
+import { Metadata } from '@/modules/core/components/texts/Metadata.tsx';
+import { AppRoutes } from '@/modules/core/AppRoute.constants.ts';
+import Link from '@mui/material/Link';
+import Stack from '@mui/material/Stack';
+import { useTranslation } from 'react-i18next';
+import { CustomTooltip } from '@/modules/core/components/CustomTooltip.tsx';
+
+interface ClickableMetadataProps {
+    title: string;
+    value: string;
+}
+
+export const ClickableMetadata = ({ title, value }: ClickableMetadataProps) => {
+    const navigate = useNavigate();
+    const { t } = useTranslation();
+
+    const unknownValue = t('global.label.unknown');
+
+    const handleClick = (searchValue: string) => {
+        if (searchValue === 'Unknown' || searchValue === unknownValue) return;
+        navigate(`${AppRoutes.library.path}?query=${encodeURIComponent(searchValue)}`);
+    };
+
+    const renderValue = () => {
+        if (value === 'Unknown' || value === unknownValue) return value;
+
+        // Handle multiple authors, split by delimiters like , | 、
+        const artists = value.split(/\s*[,|、]\s*/);
+
+        return (
+            <Stack direction="row" spacing={1} flexWrap="wrap">
+                {artists.map((artist, index) => (
+                    <span key={artist}>
+                        <CustomTooltip title={t('library.title')}>
+                            <span>
+                                <Link
+                                    component="button"
+                                    onClick={() => handleClick(artist)}
+                                    sx={{
+                                        textAlign: 'left',
+                                        '&:hover': {
+                                            cursor: 'pointer',
+                                        },
+                                    }}
+                                    disabled={artist === 'Unknown' || artist === unknownValue}
+                                >
+                                    {artist}
+                                </Link>
+                            </span>
+                        </CustomTooltip>
+                        {index < artists.length - 1 && ', '}
+                    </span>
+                ))}
+            </Stack>
+        );
+    };
+
+    return <Metadata title={title} value={renderValue()} />;
+}; 

--- a/src/modules/manga/components/MangaDetails.tsx
+++ b/src/modules/manga/components/MangaDetails.tsx
@@ -48,6 +48,7 @@ import { TAppThemeContext, useAppThemeContext } from '@/modules/theme/contexts/A
 import { applyStyles } from '@/modules/core/utils/ApplyStyles.ts';
 import { CustomButtonIcon } from '@/modules/core/components/buttons/CustomButtonIcon.tsx';
 import { Sources } from '@/modules/source/services/Sources.ts';
+import { ClickableMetadata } from '@/modules/manga/components/ClickableMetadata.tsx';
 
 const DetailsWrapper = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -416,8 +417,8 @@ export const MangaDetails = ({
                                     </IconButton>
                                 </CustomTooltip>
                             </Stack>
-                            <Metadata title={t('manga.label.author')} value={getValueOrUnknown(manga.author)} />
-                            <Metadata title={t('manga.label.artist')} value={getValueOrUnknown(manga.artist)} />
+                            <ClickableMetadata title={t('manga.label.author')} value={getValueOrUnknown(manga.author)} />
+                            <ClickableMetadata title={t('manga.label.artist')} value={getValueOrUnknown(manga.artist)} />
                             <Metadata
                                 title={t('manga.label.status')}
                                 value={t(MANGA_STATUS_TO_TRANSLATION[manga.status])}


### PR DESCRIPTION
Added the ability to sort manga by artist/author and implemented clickable artist/author links in manga details. When clicked, these links will search for other works by the same creator in the library. The feature supports multiple artists/authors separated by common delimiters (commas, vertical bars, and Chinese commas).

Key changes:
- Added new sort mode `byArtistOrAuthor`
- Created `ClickableMetadata` component for handling artist/author links
- Implemented multi-author support with delimiter splitting
- Fixed routing and search parameter handling
- Added proper translations for all supported languages

添加了按作者/画师排序漫画的功能，并在漫画详情页实现了可点击的作者/画师链接。点击这些链接可以在书库中搜索同一创作者的其他作品。该功能支持多个作者/画师（以逗号、竖线和顿号等常见分隔符分隔）。 主要修改：
- 新增 `byArtistOrAuthor` 排序模式
- 创建 `ClickableMetadata` 组件处理作者/画师链接
- 实现多作者支持，支持多种分隔符
- 修复路由和搜索参数处理
- 为所有支持的语言添加对应翻译


![image](https://github.com/user-attachments/assets/b9246937-5af2-4a8b-ad91-d437b0164f31)
![PixPin_2025-05-16_15-44-40](https://github.com/user-attachments/assets/600df7d0-112e-412f-91f2-b359cf8e81f7)

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->