### PR TITLE
Feat: Adds to Reader settings custom scroll amount slider

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -413,7 +413,6 @@
     "label": {
       "advanced": "Advanced",
       "are_you_sure": "Are you sure?",
-      "as_mousewheel": "As MouseWheel",
       "asterisk": "*",
       "auto": "Auto",
       "both": "Both",
@@ -467,6 +466,7 @@
       "stopped": "Stopped",
       "success": "Success",
       "system": "System",
+      "tiny": "Tiny",
       "type": "Type",
       "unknown": "Unknown",
       "username": "Username",
@@ -978,7 +978,6 @@
         "show_page_number": "Show page number",
         "skip_dup_chapters": "Skip duplicate chapters",
         "custom_scroll_amount": "Custom scroll amount",
-        "custom_scroll_amount_percentage": "{{count}}%",
         "static_navigation": "Static navigation"
       },
       "overlay_mode": "Overlay mode",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -413,6 +413,7 @@
     "label": {
       "advanced": "Advanced",
       "are_you_sure": "Are you sure?",
+      "as_mousewheel": "As MouseWheel",
       "asterisk": "*",
       "auto": "Auto",
       "both": "Both",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -977,6 +977,8 @@
         "reading_mode": "Reading mode",
         "show_page_number": "Show page number",
         "skip_dup_chapters": "Skip duplicate chapters",
+        "custom_scroll_amount": "Custom scroll amount",
+        "custom_scroll_amount_percentage": "{{count}}%",
         "static_navigation": "Static navigation"
       },
       "overlay_mode": "Overlay mode",

--- a/src/modules/reader/components/settings/behaviour/ReaderBehaviourSettings.tsx
+++ b/src/modules/reader/components/settings/behaviour/ReaderBehaviourSettings.tsx
@@ -40,7 +40,7 @@ export const ReaderBehaviourSettings = ({
             />
             <ReaderSettingScrollAmount
                 scrollAmount={settings.scrollAmount}
-                setScrollAmount={(value) => updateSetting('scrollAmount', value)}
+                setScrollAmount={(value, commit) => updateSetting('scrollAmount', value, commit)}
             />
             <CheckboxInput
                 label={t('reader.settings.label.skip_dup_chapters')}

--- a/src/modules/reader/components/settings/behaviour/ReaderSettingScrollAmount.tsx
+++ b/src/modules/reader/components/settings/behaviour/ReaderSettingScrollAmount.tsx
@@ -10,7 +10,12 @@ import { useTranslation } from 'react-i18next';
 import { IReaderSettings } from '@/modules/reader/types/Reader.types.ts';
 import { ValueToDisplayData } from '@/modules/core/Core.types.ts';
 import { ButtonSelectInput } from '@/modules/core/components/inputs/ButtonSelectInput.tsx';
-import { ReaderScrollAmount } from '@/modules/reader/constants/ReaderSettings.constants.tsx';
+import { SliderInput } from '@/modules/core/components/inputs/SliderInput.tsx';
+import {
+    ReaderScrollAmount,
+    DEFAULT_READER_SETTINGS,
+    SCROLL_AMOUNT,
+} from '@/modules/reader/constants/ReaderSettings.constants.tsx';
 
 const VALUE_TO_DISPLAY_DATA: ValueToDisplayData<ReaderScrollAmount> = {
     [ReaderScrollAmount.AS_MOUSEWHEEL]: {
@@ -42,12 +47,32 @@ export const ReaderSettingScrollAmount = ({
     const { t } = useTranslation();
 
     return (
-        <ButtonSelectInput
-            label={t('reader.settings.scroll_amount')}
-            value={scrollAmount}
-            values={READER_SCROLL_AMOUNT_VALUES}
-            setValue={setScrollAmount}
-            valueToDisplayData={VALUE_TO_DISPLAY_DATA}
-        />
+        <>
+            <ButtonSelectInput
+                label={t('reader.settings.scroll_amount')}
+                value={scrollAmount}
+                values={READER_SCROLL_AMOUNT_VALUES}
+                setValue={setScrollAmount}
+                valueToDisplayData={VALUE_TO_DISPLAY_DATA}
+            />
+            <SliderInput
+                label={t('reader.settings.label.custom_scroll_amount')}
+                value={t('reader.settings.label.custom_scroll_amount_percentage', { value: scrollAmount })}
+                onDefault={() => setScrollAmount(DEFAULT_READER_SETTINGS.scrollAmount)}
+                slotProps={{
+                    slider: {
+                        defaultValue: DEFAULT_READER_SETTINGS.scrollAmount,
+                        value: scrollAmount,
+                        ...SCROLL_AMOUNT,
+                        onChange: (_, value) => {
+                            setScrollAmount(value as number);
+                        },
+                        onChangeCommitted: (_, value) => {
+                            setScrollAmount(value as number);
+                        },
+                    },
+                }}
+            />
+        </>
     );
 };

--- a/src/modules/reader/components/settings/behaviour/ReaderSettingScrollAmount.tsx
+++ b/src/modules/reader/components/settings/behaviour/ReaderSettingScrollAmount.tsx
@@ -13,6 +13,10 @@ import { ButtonSelectInput } from '@/modules/core/components/inputs/ButtonSelect
 import { ReaderScrollAmount } from '@/modules/reader/constants/ReaderSettings.constants.tsx';
 
 const VALUE_TO_DISPLAY_DATA: ValueToDisplayData<ReaderScrollAmount> = {
+    [ReaderScrollAmount.AS_MOUSEWHEEL]: {
+        title: 'global.label.as_mousewheel',
+        icon: null,
+    },
     [ReaderScrollAmount.SMALL]: {
         title: 'global.label.small',
         icon: null,

--- a/src/modules/reader/components/settings/behaviour/ReaderSettingScrollAmount.tsx
+++ b/src/modules/reader/components/settings/behaviour/ReaderSettingScrollAmount.tsx
@@ -18,8 +18,8 @@ import {
 } from '@/modules/reader/constants/ReaderSettings.constants.tsx';
 
 const VALUE_TO_DISPLAY_DATA: ValueToDisplayData<ReaderScrollAmount> = {
-    [ReaderScrollAmount.AS_MOUSEWHEEL]: {
-        title: 'global.label.as_mousewheel',
+    [ReaderScrollAmount.TINY]: {
+        title: 'global.label.tiny',
         icon: null,
     },
     [ReaderScrollAmount.SMALL]: {
@@ -42,7 +42,7 @@ export const ReaderSettingScrollAmount = ({
     scrollAmount,
     setScrollAmount,
 }: Pick<IReaderSettings, 'scrollAmount'> & {
-    setScrollAmount: (amount: ReaderScrollAmount) => void;
+    setScrollAmount: (amount: ReaderScrollAmount, commit: boolean) => void;
 }) => {
     const { t } = useTranslation();
 
@@ -52,23 +52,23 @@ export const ReaderSettingScrollAmount = ({
                 label={t('reader.settings.scroll_amount')}
                 value={scrollAmount}
                 values={READER_SCROLL_AMOUNT_VALUES}
-                setValue={setScrollAmount}
+                setValue={(value) => setScrollAmount(value as number, true)}
                 valueToDisplayData={VALUE_TO_DISPLAY_DATA}
             />
             <SliderInput
                 label={t('reader.settings.label.custom_scroll_amount')}
-                value={t('reader.settings.label.custom_scroll_amount_percentage', { value: scrollAmount })}
-                onDefault={() => setScrollAmount(DEFAULT_READER_SETTINGS.scrollAmount)}
+                value={t('global.value', { value: scrollAmount, unit: '%' })}
+                onDefault={() => setScrollAmount(DEFAULT_READER_SETTINGS.scrollAmount, true)}
                 slotProps={{
                     slider: {
                         defaultValue: DEFAULT_READER_SETTINGS.scrollAmount,
                         value: scrollAmount,
                         ...SCROLL_AMOUNT,
                         onChange: (_, value) => {
-                            setScrollAmount(value as number);
+                            setScrollAmount(value as number, false);
                         },
                         onChangeCommitted: (_, value) => {
-                            setScrollAmount(value as number);
+                            setScrollAmount(value as number, true);
                         },
                     },
                 }}

--- a/src/modules/reader/constants/ReaderSettings.constants.tsx
+++ b/src/modules/reader/constants/ReaderSettings.constants.tsx
@@ -40,7 +40,7 @@ import { WebtoonPageIcon } from '@/assets/icons/svg/WebtoonPageIcon.tsx';
  * percentage values
  */
 export enum ReaderScrollAmount {
-    AS_MOUSEWHEEL = 5,
+    TINY = 10,
     SMALL = 25,
     MEDIUM = 75,
     LARGE = 95,
@@ -310,9 +310,9 @@ export const AUTO_SCROLL_SPEED = {
 };
 
 export const SCROLL_AMOUNT = {
-    min: 0.5,
+    min: 5,
     max: 100,
-    step: 0.5,
+    step: 5,
 };
 
 export const READER_BLEND_MODE_VALUE_TO_DISPLAY_DATA = {

--- a/src/modules/reader/constants/ReaderSettings.constants.tsx
+++ b/src/modules/reader/constants/ReaderSettings.constants.tsx
@@ -309,6 +309,12 @@ export const AUTO_SCROLL_SPEED = {
     step: 0.5,
 };
 
+export const SCROLL_AMOUNT = {
+    min: 0.5,
+    max: 100,
+    step: 0.5,
+};
+
 export const READER_BLEND_MODE_VALUE_TO_DISPLAY_DATA = {
     [ReaderBlendMode.DEFAULT]: {
         title: 'reader.settings.custom_filter.rgba.blend_mode.default',

--- a/src/modules/reader/constants/ReaderSettings.constants.tsx
+++ b/src/modules/reader/constants/ReaderSettings.constants.tsx
@@ -40,6 +40,7 @@ import { WebtoonPageIcon } from '@/assets/icons/svg/WebtoonPageIcon.tsx';
  * percentage values
  */
 export enum ReaderScrollAmount {
+    AS_MOUSEWHEEL = 5,
     SMALL = 25,
     MEDIUM = 75,
     LARGE = 95,


### PR DESCRIPTION
## What it does
- Added an even slower speed scroll speed `AS MOUSEWHEEL` that is set to 5%
- Added custom scroll speed slider in range `[0.5-100]`
  - The slider use the same variable as the `Scroll amount` buttons so if a button is clicked it update the slider

Example custom value image:
![immagine](https://github.com/user-attachments/assets/6fa8bcea-3786-4692-8ce1-745d7db01ab4)

Example button value image:
![immagine](https://github.com/user-attachments/assets/61c076db-d0cc-4920-a971-3627acdf0fc6)

## Why the changes?
I couldn't read the manga as it was before, when reading manga on scanalations i use arrows to scroll and it was scrolling too much of the page.
This is best in continuous or webtoon reading mode.

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->