### PR TITLE
fix(i18n): differentiate translation keys for "mark as read" actions

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -345,7 +345,7 @@
       "browse": "Browse",
       "cancel": "Cancel",
       "changelog": "Changelog",
-      "clear": "Clear",
+      "clear_selection": "Clear",
       "copy": "Copy",
       "create": "Create",
       "delete": "Delete",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -348,6 +348,7 @@
       "delete": "Delete",
       "deselect": "Deselect",
       "dont_show_dialog_again": "Don't show this dialog again",
+      "download": "Download",
       "edit": "Edit",
       "filter": "Filter",
       "ignore": "Ignore",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -114,7 +114,8 @@
           "label": {
             "action": {
               "current": "Mark as read",
-              "previous": "Mark previous as read"
+              "previous": "Mark previous as read",
+              "all": "Mark all as read"
             },
             "confirmation_one": "You are about to mark one chapter as read",
             "confirmation_other": "You are about to mark {{count}} chapters as read",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -103,6 +103,9 @@
           }
         }
       },
+      "filter_and_sort": {
+        "label": "Filter and sort"
+      },
       "label": {
         "select": "Select"
       },

--- a/src/features/app-updates/components/ServerUpdateChecker.tsx
+++ b/src/features/app-updates/components/ServerUpdateChecker.tsx
@@ -102,7 +102,7 @@ export const ServerUpdateChecker = () => {
                     channel: selectedServerChannelInfo.channel,
                     version: selectedServerChannelInfo.tag,
                 })}
-                actionTitle={t('chapter.action.download.add.label.action')}
+                actionTitle={t('global.button.download')}
                 actionUrl={selectedServerChannelInfo.url}
                 updateCheckerProps={['server', checkForUpdate, selectedServerChannelInfo?.tag]}
             />

--- a/src/features/chapter/components/ChaptersToolbarMenu.tsx
+++ b/src/features/chapter/components/ChaptersToolbarMenu.tsx
@@ -71,7 +71,7 @@ export const ChaptersToolbarMenu = ({
                 {(popupState) => (
                     <>
                         <CustomTooltip
-                            title={t('chapter.action.download.add.label.action')}
+                            title={t('global.button.download')}
                             disabled={areAllChaptersRead}
                         >
                             <IconButton

--- a/src/features/chapter/components/ChaptersToolbarMenu.tsx
+++ b/src/features/chapter/components/ChaptersToolbarMenu.tsx
@@ -56,7 +56,7 @@ export const ChaptersToolbarMenu = ({
     return (
         <>
             <CustomTooltip
-                title={t('chapter.action.mark_as_read.add.label.action.current')}
+                title={t('chapter.action.mark_as_read.add.label.action.all')}
                 disabled={areAllChaptersRead}
             >
                 <IconButton

--- a/src/features/chapter/components/ChaptersToolbarMenu.tsx
+++ b/src/features/chapter/components/ChaptersToolbarMenu.tsx
@@ -55,10 +55,7 @@ export const ChaptersToolbarMenu = ({
 
     return (
         <>
-            <CustomTooltip
-                title={t('chapter.action.mark_as_read.add.label.action.all')}
-                disabled={areAllChaptersRead}
-            >
+            <CustomTooltip title={t('chapter.action.mark_as_read.add.label.action.all')} disabled={areAllChaptersRead}>
                 <IconButton
                     disabled={areAllChaptersRead}
                     onClick={() => Chapters.markAsRead(Chapters.getNonRead(chapters), true, mangaId)}
@@ -70,10 +67,7 @@ export const ChaptersToolbarMenu = ({
             <PopupState variant="popover" popupId="chapterlist-download-button">
                 {(popupState) => (
                     <>
-                        <CustomTooltip
-                            title={t('global.button.download')}
-                            disabled={areAllChaptersRead}
-                        >
+                        <CustomTooltip title={t('global.button.download')} disabled={areAllChaptersRead}>
                             <IconButton
                                 disabled={areAllChaptersDownloaded}
                                 {...bindTrigger(popupState)}

--- a/src/features/chapter/components/ChaptersToolbarMenu.tsx
+++ b/src/features/chapter/components/ChaptersToolbarMenu.tsx
@@ -90,7 +90,7 @@ export const ChaptersToolbarMenu = ({
                     </>
                 )}
             </PopupState>
-            <CustomTooltip title={t('settings.title')}>
+            <CustomTooltip title={t('chapter.action.filter_and_sort.label')}>
                 <IconButton onClick={() => setOpen(true)} color="inherit">
                     <FilterList color={isFiltered ? 'warning' : undefined} />
                 </IconButton>

--- a/src/features/collection/components/SelectableCollectionSelectAll.tsx
+++ b/src/features/collection/components/SelectableCollectionSelectAll.tsx
@@ -22,7 +22,7 @@ export const SelectableCollectionSelectAll = ({
     const { t } = useTranslation();
 
     return (
-        <CustomTooltip title={t(!areAllItemsSelected ? 'global.button.select_all' : 'global.button.clear')}>
+        <CustomTooltip title={t(!areAllItemsSelected ? 'global.button.select_all' : 'global.button.clear_selection')}>
             <Checkbox
                 sx={{
                     padding: '8px',


### PR DESCRIPTION
This PR adjusts translation keys in the chapter module to improve localization consistency. 

It separates the use of `chapter.action.mark_as_read.add.label.action.current` and introduces `chapter.action.mark_as_read.add.label.action.all` in `ChaptersToolbarMenu.tsx`, without changing any functionality.