### PR TITLE
Add per-manga notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- (**Manga**) Add per-manga notes
 - (**Download**) Add button to retry all failed downloads
 
 ### Changed

--- a/src/features/manga/Manga.types.ts
+++ b/src/features/manga/Manga.types.ts
@@ -25,6 +25,7 @@ import type { MigrationMatch } from '@/features/migration/Migration.types.ts';
 import type {
     MangaType as MangaTypeGql,
     Maybe,
+    MetaType,
     SourceType,
     TrackRecordType,
 } from '@/lib/graphql/generated/graphql-base.types.ts';
@@ -60,6 +61,7 @@ export type MangaTitleInfo = Pick<MangaTypeGql, 'title'>;
 export type MangaDescriptionInfo = Pick<MangaTypeGql, 'description'>;
 export type MangaStatusInfo = Pick<MangaTypeGql, 'status'>;
 export type MangaUrlInfo = Pick<MangaTypeGql, 'realUrl'>;
+export type MangaMetaInfo = { meta?: Pick<MetaType, 'key' | 'value'>[] };
 
 type MangaCardSpecificProps = MangaCardBaseProps & MangaThumbnailInfo;
 
@@ -83,7 +85,9 @@ export type SpecificMangaCardProps = Omit<MangaCardProps, 'manga'> &
         mangaBadges: JSX.Element;
     };
 
-export type MangaMetadata = ChapterListOptions;
+export type MangaMetadata = ChapterListOptions & {
+    notes: string;
+};
 
 export type MangaMetadataKeys = keyof MangaMetadata;
 

--- a/src/features/manga/components/details/DescriptionGenre.tsx
+++ b/src/features/manga/components/details/DescriptionGenre.tsx
@@ -19,23 +19,27 @@ import { useResizeObserver } from '@/base/hooks/useResizeObserver.tsx';
 import type {
     MangaDescriptionInfo,
     MangaGenreInfo,
+    MangaIdInfo,
     MangaLocationState,
+    MangaMetaInfo,
     MangaSourceIdInfo,
 } from '@/features/manga/Manga.types.ts';
 import { SearchLink } from '@/features/manga/components/details/SearchLink.tsx';
+import { MangaNotes } from '@/features/manga/components/details/MangaNotes.tsx';
 import uniq from 'lodash/fp/uniq';
 
 const OPEN_CLOSE_BUTTON_HEIGHT = '35px';
 const DESCRIPTION_COLLAPSED_SIZE = 75;
 
 export const DescriptionGenre = ({
-    manga: { description, genre: mangaGenres, sourceId },
+    manga,
     mode,
 }: {
-    manga: MangaDescriptionInfo & MangaGenreInfo & MangaSourceIdInfo;
+    manga: MangaDescriptionInfo & MangaGenreInfo & MangaIdInfo & MangaMetaInfo & MangaSourceIdInfo;
     mode: MangaLocationState['mode'];
 }) => {
-    const [descriptionElement, setDescriptionElement] = useState<HTMLSpanElement | null>(null);
+    const { description, genre: mangaGenres, sourceId } = manga;
+    const [descriptionElement, setDescriptionElement] = useState<HTMLDivElement | null>(null);
     const [descriptionHeight, setDescriptionHeight] = useState<number>();
     useResizeObserver(
         descriptionElement,
@@ -54,17 +58,24 @@ export const DescriptionGenre = ({
             {description && (
                 <Stack sx={{ position: 'relative' }}>
                     <Collapse collapsedSize={collapsedSize} in={!isCollapsed}>
-                        <Typography
+                        <Stack
                             ref={setDescriptionElement}
                             sx={{
-                                whiteSpace: 'pre-line',
-                                textAlign: 'justify',
-                                textJustify: 'inter-word',
+                                gap: 1,
                                 mb: OPEN_CLOSE_BUTTON_HEIGHT,
                             }}
                         >
-                            {description}
-                        </Typography>
+                            <MangaNotes manga={manga} expanded={!isCollapsed} />
+                            <Typography
+                                sx={{
+                                    whiteSpace: 'pre-line',
+                                    textAlign: 'justify',
+                                    textJustify: 'inter-word',
+                                }}
+                            >
+                                {description}
+                            </Typography>
+                        </Stack>
                     </Collapse>
                     <Stack
                         onClick={() => setIsCollapsed(!isCollapsed)}
@@ -86,6 +97,7 @@ export const DescriptionGenre = ({
                     </Stack>
                 </Stack>
             )}
+            {!description && <MangaNotes manga={manga} expanded />}
             <Stack
                 sx={{
                     flexDirection: 'row',

--- a/src/features/manga/components/details/DescriptionGenre.tsx
+++ b/src/features/manga/components/details/DescriptionGenre.tsx
@@ -26,6 +26,7 @@ import type {
 } from '@/features/manga/Manga.types.ts';
 import { SearchLink } from '@/features/manga/components/details/SearchLink.tsx';
 import { MangaNotes } from '@/features/manga/components/details/MangaNotes.tsx';
+import { useGetMangaMetadata } from '@/features/manga/services/MangaMetadata.ts';
 import uniq from 'lodash/fp/uniq';
 
 const OPEN_CLOSE_BUTTON_HEIGHT = '35px';
@@ -39,6 +40,9 @@ export const DescriptionGenre = ({
     mode: MangaLocationState['mode'];
 }) => {
     const { description, genre: mangaGenres, sourceId } = manga;
+    const { notes } = useGetMangaMetadata(manga);
+    const hasNotes = notes.trim().length > 0;
+    const hasCollapsibleContent = !!description || hasNotes;
     const [descriptionElement, setDescriptionElement] = useState<HTMLDivElement | null>(null);
     const [descriptionHeight, setDescriptionHeight] = useState<number>();
     useResizeObserver(
@@ -48,14 +52,14 @@ export const DescriptionGenre = ({
 
     const [isCollapsed, setIsCollapsed] = useLocalStorage('isDescriptionGenreCollapsed', true);
 
-    const collapsedSize = description
+    const collapsedSize = hasCollapsibleContent
         ? Math.min(DESCRIPTION_COLLAPSED_SIZE, descriptionHeight ?? DESCRIPTION_COLLAPSED_SIZE)
         : 0;
     const genres = useMemo(() => uniq(mangaGenres.filter(Boolean)), [mangaGenres]);
 
     return (
         <>
-            {description && (
+            {hasCollapsibleContent ? (
                 <Stack sx={{ position: 'relative' }}>
                     <Collapse collapsedSize={collapsedSize} in={!isCollapsed}>
                         <Stack
@@ -65,16 +69,18 @@ export const DescriptionGenre = ({
                                 mb: OPEN_CLOSE_BUTTON_HEIGHT,
                             }}
                         >
-                            <MangaNotes manga={manga} expanded={!isCollapsed} />
-                            <Typography
-                                sx={{
-                                    whiteSpace: 'pre-line',
-                                    textAlign: 'justify',
-                                    textJustify: 'inter-word',
-                                }}
-                            >
-                                {description}
-                            </Typography>
+                            <MangaNotes manga={manga} expanded={!isCollapsed} showDivider={!!description} />
+                            {description && (
+                                <Typography
+                                    sx={{
+                                        whiteSpace: 'pre-line',
+                                        textAlign: 'justify',
+                                        textJustify: 'inter-word',
+                                    }}
+                                >
+                                    {description}
+                                </Typography>
+                            )}
                         </Stack>
                     </Collapse>
                     <Stack
@@ -96,8 +102,9 @@ export const DescriptionGenre = ({
                         </IconButton>
                     </Stack>
                 </Stack>
+            ) : (
+                <MangaNotes manga={manga} expanded showDivider={false} />
             )}
-            {!description && <MangaNotes manga={manga} expanded />}
             <Stack
                 sx={{
                     flexDirection: 'row',

--- a/src/features/manga/components/details/MangaDetails.tsx
+++ b/src/features/manga/components/details/MangaDetails.tsx
@@ -38,6 +38,7 @@ import type {
     MangaIdInfo,
     MangaInLibraryInfo,
     MangaLocationState,
+    MangaMetaInfo,
     MangaSourceIdInfo,
     MangaStatusInfo,
     MangaThumbnailInfo,
@@ -222,7 +223,8 @@ export const MangaDetails = ({
         MangaGenreInfo &
         MangaThumbnailInfo &
         MangaSourceIdInfo &
-        MangaTrackRecordInfo & {
+        MangaTrackRecordInfo &
+        MangaMetaInfo & {
             source?: Pick<SourceType, 'id' | 'displayName'> | null;
         };
     mode: MangaLocationState['mode'];

--- a/src/features/manga/components/details/MangaNotes.tsx
+++ b/src/features/manga/components/details/MangaNotes.tsx
@@ -6,7 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import NoteAddOutlinedIcon from '@mui/icons-material/NoteAddOutlined';
 import NoteAltOutlinedIcon from '@mui/icons-material/NoteAltOutlined';
 import Button from '@mui/material/Button';
@@ -24,19 +24,9 @@ import type { MangaIdInfo, MangaMetaInfo } from '@/features/manga/Manga.types.ts
 import { updateMangaMetadata, useGetMangaMetadata } from '@/features/manga/services/MangaMetadata.ts';
 import { getErrorMessage } from '@/lib/HelperFunctions.ts';
 
-
-export const MangaNotesButton = ({
-    manga,
-    notes,
-    onSaved,
-}: {
-    manga: MangaIdInfo & MangaMetaInfo;
-    notes: string;
-    onSaved: (notes: string) => void;
-}) => {
+export const MangaNotesButton = ({ manga, notes }: { manga: MangaIdInfo & MangaMetaInfo; notes: string }) => {
     const { t } = useLingui();
     const [isOpen, setIsOpen] = useState(false);
-    const [isSaving, setIsSaving] = useState(false);
     const [draft, setDraft] = useState(notes);
 
     const openDialog = () => {
@@ -44,26 +34,15 @@ export const MangaNotesButton = ({
         setIsOpen(true);
     };
 
-    const closeDialog = () => {
-        if (!isSaving) {
-            setIsOpen(false);
-        }
-    };
+    const closeDialog = () => setIsOpen(false);
 
-    const saveNotes = async () => {
+    const saveNotes = () => {
         const nextNotes = draft.trimEnd();
-        setIsSaving(true);
+        setIsOpen(false);
 
-        try {
-            await updateMangaMetadata(manga, 'notes', nextNotes);
-            onSaved(nextNotes);
-            setIsOpen(false);
-            makeToast(t`Notes saved`, 'success');
-        } catch (error) {
-            makeToast(t`Could not save notes`, 'error', getErrorMessage(error));
-        } finally {
-            setIsSaving(false);
-        }
+        void updateMangaMetadata(manga, 'notes', nextNotes)
+            .then(() => makeToast(t`Notes saved`, 'success'))
+            .catch((error) => makeToast(t`Could not save notes`, 'error', getErrorMessage(error)));
     };
 
     const hasNotes = notes.trim().length > 0;
@@ -79,8 +58,8 @@ export const MangaNotesButton = ({
             >
                 {hasNotes ? t`Edit notes` : t`Add notes`}
             </Button>
-            <Dialog open={isOpen} onClose={closeDialog} aria-labelledby={titleId} fullWidth maxWidth="sm">
-                <DialogTitle id={titleId}>{hasNotes ? t`Edit notes` : t`Add notes`}</DialogTitle>
+            <Dialog open={isOpen} onClose={closeDialog} fullWidth maxWidth="sm">
+                <DialogTitle>{hasNotes ? t`Edit notes` : t`Add notes`}</DialogTitle>
                 <DialogContent>
                     <TextField
                         autoFocus
@@ -92,7 +71,6 @@ export const MangaNotesButton = ({
                         label={t`Notes`}
                         placeholder={t`Add a private note about this manga`}
                         value={draft}
-                        disabled={isSaving}
                         onChange={(event) => setDraft(event.target.value)}
                         onKeyDown={(event) => {
                             if ((event.ctrlKey || event.metaKey) && event.key === 'Enter' && !isUnchanged) {
@@ -103,11 +81,9 @@ export const MangaNotesButton = ({
                     />
                 </DialogContent>
                 <DialogActions>
-                    <Button onClick={closeDialog} disabled={isSaving}>
-                        {t`Cancel`}
-                    </Button>
-                    <Button onClick={() => void saveNotes()} disabled={isSaving || isUnchanged} variant="contained">
-                        {isSaving ? t`Saving…` : t`Save`}
+                    <Button onClick={closeDialog}>{t`Cancel`}</Button>
+                    <Button onClick={saveNotes} disabled={isUnchanged} variant="contained">
+                        {t`Save`}
                     </Button>
                 </DialogActions>
             </Dialog>
@@ -115,7 +91,15 @@ export const MangaNotesButton = ({
     );
 };
 
-export const MangaNotes = ({ manga, expanded }: { manga: MangaIdInfo & MangaMetaInfo; expanded: boolean }) => {
+export const MangaNotes = ({
+    manga,
+    expanded,
+    showDivider,
+}: {
+    manga: MangaIdInfo & MangaMetaInfo;
+    expanded: boolean;
+    showDivider: boolean;
+}) => {
     const { notes } = useGetMangaMetadata(manga);
     const hasNotes = notes.trim().length > 0;
 
@@ -131,8 +115,8 @@ export const MangaNotes = ({ manga, expanded }: { manga: MangaIdInfo & MangaMeta
                     {notes}
                 </Typography>
             )}
-            {(!hasNotes || expanded) && <MangaNotesButton manga={manga} notes={notes} onSaved={setNotes} />}
-            {hasNotes && <Divider flexItem />}
+            {(!hasNotes || expanded) && <MangaNotesButton manga={manga} notes={notes} />}
+            {hasNotes && showDivider && <Divider flexItem />}
         </Stack>
     );
 };

--- a/src/features/manga/components/details/MangaNotes.tsx
+++ b/src/features/manga/components/details/MangaNotes.tsx
@@ -24,19 +24,6 @@ import type { MangaIdInfo, MangaMetaInfo } from '@/features/manga/Manga.types.ts
 import { updateMangaMetadata, useGetMangaMetadata } from '@/features/manga/services/MangaMetadata.ts';
 import { getErrorMessage } from '@/lib/HelperFunctions.ts';
 
-type MangaNotesState = {
-    notes: string;
-    setNotes: (notes: string) => void;
-};
-
-export const useMangaNotes = (manga: MangaIdInfo & MangaMetaInfo): MangaNotesState => {
-    const { notes: storedNotes } = useGetMangaMetadata(manga);
-    const [notes, setNotes] = useState(storedNotes);
-
-    useEffect(() => setNotes(storedNotes), [storedNotes]);
-
-    return { notes, setNotes };
-};
 
 export const MangaNotesButton = ({
     manga,

--- a/src/features/manga/components/details/MangaNotes.tsx
+++ b/src/features/manga/components/details/MangaNotes.tsx
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { useEffect, useState } from 'react';
+import NoteAddOutlinedIcon from '@mui/icons-material/NoteAddOutlined';
+import NoteAltOutlinedIcon from '@mui/icons-material/NoteAltOutlined';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Divider from '@mui/material/Divider';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import { useLingui } from '@lingui/react/macro';
+import { makeToast } from '@/base/utils/Toast.ts';
+import type { MangaIdInfo, MangaMetaInfo } from '@/features/manga/Manga.types.ts';
+import { updateMangaMetadata, useGetMangaMetadata } from '@/features/manga/services/MangaMetadata.ts';
+import { getErrorMessage } from '@/lib/HelperFunctions.ts';
+
+type MangaNotesState = {
+    notes: string;
+    setNotes: (notes: string) => void;
+};
+
+export const useMangaNotes = (manga: MangaIdInfo & MangaMetaInfo): MangaNotesState => {
+    const { notes: storedNotes } = useGetMangaMetadata(manga);
+    const [notes, setNotes] = useState(storedNotes);
+
+    useEffect(() => setNotes(storedNotes), [storedNotes]);
+
+    return { notes, setNotes };
+};
+
+export const MangaNotesButton = ({
+    manga,
+    notes,
+    onSaved,
+}: {
+    manga: MangaIdInfo & MangaMetaInfo;
+    notes: string;
+    onSaved: (notes: string) => void;
+}) => {
+    const { t } = useLingui();
+    const [isOpen, setIsOpen] = useState(false);
+    const [isSaving, setIsSaving] = useState(false);
+    const [draft, setDraft] = useState(notes);
+
+    const openDialog = () => {
+        setDraft(notes);
+        setIsOpen(true);
+    };
+
+    const closeDialog = () => {
+        if (!isSaving) {
+            setIsOpen(false);
+        }
+    };
+
+    const saveNotes = async () => {
+        const nextNotes = draft.trimEnd();
+        setIsSaving(true);
+
+        try {
+            await updateMangaMetadata(manga, 'notes', nextNotes);
+            onSaved(nextNotes);
+            setIsOpen(false);
+            makeToast(t`Notes saved`, 'success');
+        } catch (error) {
+            makeToast(t`Could not save notes`, 'error', getErrorMessage(error));
+        } finally {
+            setIsSaving(false);
+        }
+    };
+
+    const hasNotes = notes.trim().length > 0;
+    const isUnchanged = draft.trimEnd() === notes;
+    const titleId = 'manga-notes-dialog-title';
+
+    return (
+        <>
+            <Button
+                size="small"
+                onClick={openDialog}
+                variant={hasNotes ? 'text' : 'outlined'}
+                startIcon={hasNotes ? <NoteAltOutlinedIcon /> : <NoteAddOutlinedIcon />}
+            >
+                {hasNotes ? t`Edit notes` : t`Add notes`}
+            </Button>
+            <Dialog open={isOpen} onClose={closeDialog} aria-labelledby={titleId} fullWidth maxWidth="sm">
+                <DialogTitle id={titleId}>{hasNotes ? t`Edit notes` : t`Add notes`}</DialogTitle>
+                <DialogContent>
+                    <TextField
+                        autoFocus
+                        multiline
+                        minRows={5}
+                        maxRows={14}
+                        fullWidth
+                        margin="dense"
+                        label={t`Notes`}
+                        placeholder={t`Add a private note about this manga`}
+                        value={draft}
+                        disabled={isSaving}
+                        onChange={(event) => setDraft(event.target.value)}
+                        onKeyDown={(event) => {
+                            if ((event.ctrlKey || event.metaKey) && event.key === 'Enter' && !isUnchanged) {
+                                event.preventDefault();
+                                void saveNotes();
+                            }
+                        }}
+                    />
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={closeDialog} disabled={isSaving}>
+                        {t`Cancel`}
+                    </Button>
+                    <Button onClick={() => void saveNotes()} disabled={isSaving || isUnchanged} variant="contained">
+                        {isSaving ? t`Saving…` : t`Save`}
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        </>
+    );
+};
+
+export const MangaNotes = ({ manga, expanded }: { manga: MangaIdInfo & MangaMetaInfo; expanded: boolean }) => {
+    const { notes, setNotes } = useMangaNotes(manga);
+    const hasNotes = notes.trim().length > 0;
+
+    return (
+        <Stack sx={{ alignItems: 'flex-start', gap: 1 }}>
+            {hasNotes && (
+                <Typography
+                    sx={{
+                        overflowWrap: 'anywhere',
+                        whiteSpace: 'pre-wrap',
+                    }}
+                >
+                    {notes}
+                </Typography>
+            )}
+            {(!hasNotes || expanded) && <MangaNotesButton manga={manga} notes={notes} onSaved={setNotes} />}
+            {hasNotes && <Divider flexItem />}
+        </Stack>
+    );
+};

--- a/src/features/manga/components/details/MangaNotes.tsx
+++ b/src/features/manga/components/details/MangaNotes.tsx
@@ -68,7 +68,6 @@ export const MangaNotesButton = ({
 
     const hasNotes = notes.trim().length > 0;
     const isUnchanged = draft.trimEnd() === notes;
-    const titleId = 'manga-notes-dialog-title';
 
     return (
         <>

--- a/src/features/manga/components/details/MangaNotes.tsx
+++ b/src/features/manga/components/details/MangaNotes.tsx
@@ -116,7 +116,7 @@ export const MangaNotesButton = ({
 };
 
 export const MangaNotes = ({ manga, expanded }: { manga: MangaIdInfo & MangaMetaInfo; expanded: boolean }) => {
-    const { notes, setNotes } = useMangaNotes(manga);
+    const { notes } = useGetMangaMetadata(manga);
     const hasNotes = notes.trim().length > 0;
 
     return (

--- a/src/features/manga/services/MangaMetadata.ts
+++ b/src/features/manga/services/MangaMetadata.ts
@@ -25,6 +25,7 @@ import { defaultPromiseErrorHandler } from '@/lib/DefaultPromiseErrorHandler.ts'
 
 const DEFAULT_MANGA_METADATA: MangaMetadata = {
     ...DEFAULT_CHAPTER_OPTIONS,
+    notes: '',
 };
 
 const convertAppMetadataToGqlMetadata = (

--- a/src/features/metadata/Metadata.constants.ts
+++ b/src/features/metadata/Metadata.constants.ts
@@ -400,6 +400,9 @@ export const APP_METADATA: Record<
     excludedScanlators: {
         convert: convertToObject<string[]>,
     },
+    notes: {
+        convert: convertToString,
+    },
     locale: {
         convert: convertToString,
         toConstrainedValue: (value: string) => {
@@ -510,6 +513,7 @@ export const GLOBAL_METADATA_KEYS: AppMetadataKeys[] = [
     'unread',
     'showChapterNumber',
     'excludedScanlators',
+    'notes',
 ];
 
 /**

--- a/src/i18n/locales/en.po
+++ b/src/i18n/locales/en.po
@@ -407,6 +407,10 @@ msgstr "Active setting ({title})"
 msgid "Add"
 msgstr "Add"
 
+#: src/features/manga/components/details/MangaNotes.tsx
+msgid "Add a private note about this manga"
+msgstr "Add a private note about this manga"
+
 #: src/features/chapter/Chapter.constants.ts
 msgid "Add bookmark"
 msgstr "Add bookmark"
@@ -415,6 +419,10 @@ msgstr "Add bookmark"
 #: src/features/extension/store/screens/ExtensionStores.tsx
 msgid "Add extension store"
 msgstr "Add extension store"
+
+#: src/features/manga/components/details/MangaNotes.tsx
+msgid "Add notes"
+msgstr "Add notes"
 
 #: src/features/manga/components/details/MangaDetails.tsx
 #: src/features/manga/components/MangaBadges.tsx
@@ -765,6 +773,7 @@ msgstr "Can't migrate an entry to itself"
 #: src/features/category/components/CategorySelect.tsx
 #: src/features/category/components/CreateOrEditCategoryDialog.tsx
 #: src/features/downloads/components/DownloadQueueChapterCard.tsx
+#: src/features/manga/components/details/MangaNotes.tsx
 #: src/features/migration/components/MigrationBulkSearchOptionsDialog.tsx
 #: src/features/migration/components/MigrationOptionsDialog.tsx
 #: src/features/reader/hotkeys/settings/components/RecordHotkey.tsx
@@ -1193,6 +1202,10 @@ msgstr "Could not retry failed downloads"
 msgid "Could not save changes"
 msgstr "Could not save changes"
 
+#: src/features/manga/components/details/MangaNotes.tsx
+msgid "Could not save notes"
+msgstr "Could not save notes"
+
 #: src/features/category/components/CategorySelect.tsx
 #: src/features/library/components/LibraryOptionsPanel.tsx
 #: src/features/library/screens/LibrarySettings.tsx
@@ -1612,6 +1625,10 @@ msgstr "Edit category"
 #: src/features/manga/components/MangaToolbarMenu.tsx
 msgid "Edit manga categories"
 msgstr "Edit manga categories"
+
+#: src/features/manga/components/details/MangaNotes.tsx
+msgid "Edit notes"
+msgstr "Edit notes"
 
 #: src/features/theme/components/CreateThemeDialog.tsx
 msgid "Edit theme"
@@ -2738,6 +2755,14 @@ msgstr "Not yet published"
 msgid "Not yet released"
 msgstr "Not yet released"
 
+#: src/features/manga/components/details/MangaNotes.tsx
+msgid "Notes"
+msgstr "Notes"
+
+#: src/features/manga/components/details/MangaNotes.tsx
+msgid "Notes saved"
+msgstr "Notes saved"
+
 #: src/features/tracker/Tracker.constants.ts
 msgid "Novel"
 msgstr "Novel"
@@ -3185,6 +3210,7 @@ msgstr "Right to left"
 msgid "Rosegold"
 msgstr "Rosegold"
 
+#: src/features/manga/components/details/MangaNotes.tsx
 #: src/features/settings/screens/ImageProcessingSetting.tsx
 #: src/features/theme/components/CreateThemeDialog.tsx
 msgid "Save"
@@ -3214,6 +3240,10 @@ msgstr "Saved theme changes"
 #: src/features/theme/components/CreateThemeDialog.tsx
 msgid "Saving theme changes…"
 msgstr "Saving theme changes…"
+
+#: src/features/manga/components/details/MangaNotes.tsx
+msgid "Saving…"
+msgstr "Saving…"
 
 #: src/features/reader/overlay/navigation/desktop/quick-settings/components/ReaderNavBarDesktopPageScale.tsx
 #: src/features/reader/settings/layout/components/ReaderSettingPageScaleMode.tsx

--- a/src/i18n/locales/en.po
+++ b/src/i18n/locales/en.po
@@ -3241,10 +3241,6 @@ msgstr "Saved theme changes"
 msgid "Saving theme changes…"
 msgstr "Saving theme changes…"
 
-#: src/features/manga/components/details/MangaNotes.tsx
-msgid "Saving…"
-msgstr "Saving…"
-
 #: src/features/reader/overlay/navigation/desktop/quick-settings/components/ReaderNavBarDesktopPageScale.tsx
 #: src/features/reader/settings/layout/components/ReaderSettingPageScaleMode.tsx
 msgid "Scale type"


### PR DESCRIPTION
## Summary

- add notes backed by manga metadata
- add a multiline add/edit dialog to manga actions
- show saved notes on the manga details screen
- provide save progress, success/error feedback, and Ctrl/Cmd+Enter submission

## Rationale

Notes make it possible to retain personal context such as reading reminders or comments without changing manga titles or categories. Storing them as manga metadata keeps them with the existing server-side WebUI preferences.

## Testing

- `pnpm format:check`
- `pnpm tsc`
- `pnpm lint`
- `pnpm build`
- saved, reloaded, edited, and cleared a multiline note in desktop and mobile layouts