### PR TITLE
Add reset button for library filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - (**Download**) Add button to retry all failed downloads
+- (**Library**) Add `reset` button to library filters
 
 ### Changed
 

--- a/src/features/category/services/CategoryMetadata.ts
+++ b/src/features/category/services/CategoryMetadata.ts
@@ -97,16 +97,18 @@ export const batchUpdateCategoryMetadata = async <
     updates: Array<{
         categories: (CategoryIdInfo & GqlMetaHolder)[];
         entries: Array<{ metadataKey: MetadataKey; value: ICategoryMetadata[MetadataKey] }>;
+        delete?: MetadataKeys[];
     }>,
 ): Promise<void> =>
     requestBatchCategoryMetadataUpdate(
-        updates.map(({ categories, entries }) => ({
+        updates.map(({ categories, entries, delete: keysToDelete }) => ({
             categories,
             options: {
                 update: entries.map(({ metadataKey, value }) => [
                     metadataKey,
                     convertAppMetadataToGqlMetadata({ [metadataKey]: value })[metadataKey],
                 ]),
+                delete: keysToDelete,
             },
         })),
     );

--- a/src/features/library/components/LibraryOptionsPanel.tsx
+++ b/src/features/library/components/LibraryOptionsPanel.tsx
@@ -82,10 +82,18 @@ export const LibraryOptionsPanel = ({
     category,
     open,
     onClose,
+    active,
+    isStatusFilterActive,
+    isTrackerFilterActive,
+    isSourceFilterActive,
 }: {
     category: CategoryMetadataInfo;
     open: boolean;
     onClose: () => void;
+    active: boolean;
+    isStatusFilterActive: boolean;
+    isTrackerFilterActive: boolean;
+    isSourceFilterActive: boolean;
 }) => {
     const { t } = useLingui();
 
@@ -105,23 +113,6 @@ export const LibraryOptionsPanel = ({
     const setSettingValue = createUpdateMetadataServerSettings((e) =>
         makeToast(t`Could not save the default search settings to the server`, 'error', getErrorMessage(e)),
     );
-
-    const isStatusFilterActive = Object.values(MangaStatus).some(
-        (status) => categoryLibraryOptions.hasStatus[status] != null,
-    );
-    const isTrackerFilterActive = loggedInTrackers.some(
-        (tracker) => categoryLibraryOptions.hasTrackerBinding[tracker.id] != null,
-    );
-    const isSourceFilterActive = librarySources.some((source) => categoryLibraryOptions.hasSource[source.id] != null);
-    const areFiltersActive =
-        categoryLibraryOptions.hasUnreadChapters != null ||
-        categoryLibraryOptions.hasReadChapters != null ||
-        categoryLibraryOptions.hasDownloadedChapters != null ||
-        categoryLibraryOptions.hasBookmarkedChapters != null ||
-        categoryLibraryOptions.hasDuplicateChapters != null ||
-        isStatusFilterActive ||
-        isTrackerFilterActive ||
-        isSourceFilterActive;
 
     const resetFilters = () => {
         batchUpdateCategoryMetadata([
@@ -153,7 +144,7 @@ export const LibraryOptionsPanel = ({
                     return (
                         <>
                             <ResetButton
-                                disabled={!areFiltersActive}
+                                disabled={!active}
                                 onClick={resetFilters}
                                 sx={{ alignSelf: 'flex-end' }}
                                 variant="outlined"

--- a/src/features/library/components/LibraryOptionsPanel.tsx
+++ b/src/features/library/components/LibraryOptionsPanel.tsx
@@ -127,19 +127,19 @@ export const LibraryOptionsPanel = ({
         batchUpdateCategoryMetadata([
             {
                 categories: [category],
-                entries: [
-                    { metadataKey: 'hasUnreadChapters', value: undefined },
-                    { metadataKey: 'hasReadChapters', value: undefined },
-                    { metadataKey: 'hasDownloadedChapters', value: undefined },
-                    { metadataKey: 'hasBookmarkedChapters', value: undefined },
-                    { metadataKey: 'hasDuplicateChapters', value: undefined },
-                    { metadataKey: 'hasStatus', value: {} },
-                    { metadataKey: 'hasTrackerBinding', value: {} },
-                    { metadataKey: 'hasSource', value: {} },
+                entries: [],
+                delete: [
+                    'hasUnreadChapters',
+                    'hasReadChapters',
+                    'hasDownloadedChapters',
+                    'hasBookmarkedChapters',
+                    'hasDuplicateChapters',
+                    'hasStatus',
+                    'hasTrackerBinding',
+                    'hasSource',
                 ],
             },
-        ]).catch((e) => makeToast(t`Failed to reset filters`, 'error', getErrorMessage(e)));
-        onClose();
+        ]).catch((e) => makeToast(t`Could not reset filters`, 'error', getErrorMessage(e)));
     };
 
     return (
@@ -152,13 +152,13 @@ export const LibraryOptionsPanel = ({
                 if (key === 'filter') {
                     return (
                         <>
-                            {areFiltersActive && (
-                                <ResetButton
-                                    onClick={resetFilters}
-                                    sx={{ alignSelf: 'flex-start' }}
-                                    variant="outlined"
-                                />
-                            )}
+                            <ResetButton
+                                disabled={!areFiltersActive}
+                                onClick={resetFilters}
+                                sx={{ alignSelf: 'flex-end' }}
+                                variant="outlined"
+                                size="small"
+                            />
                             <ThreeStateCheckboxInput
                                 label={t`Unread`}
                                 checked={categoryLibraryOptions.hasUnreadChapters}

--- a/src/features/library/components/LibraryOptionsPanel.tsx
+++ b/src/features/library/components/LibraryOptionsPanel.tsx
@@ -23,7 +23,11 @@ import type { GetTrackersSettingsQuery } from '@/lib/graphql/generated/graphql.t
 import { MangaStatus } from '@/lib/graphql/generated/graphql-base.types.ts';
 import { GET_TRACKERS_SETTINGS } from '@/lib/graphql/tracker/TrackerQuery.ts';
 import { STABLE_EMPTY_ARRAY } from '@/base/Base.constants.ts';
-import { createUpdateCategoryMetadata, useGetCategoryMetadata } from '@/features/category/services/CategoryMetadata.ts';
+import {
+    batchUpdateCategoryMetadata,
+    createUpdateCategoryMetadata,
+    useGetCategoryMetadata,
+} from '@/features/category/services/CategoryMetadata.ts';
 import { makeToast } from '@/base/utils/Toast.ts';
 import {
     createUpdateMetadataServerSettings,
@@ -36,6 +40,7 @@ import { MANGA_STATUS_TO_TRANSLATION } from '@/features/manga/Manga.constants.ts
 import { GridLayout } from '@/base/Base.types';
 import { getErrorMessage } from '@/lib/HelperFunctions.ts';
 import { Collapsable } from '@/base/components/Collapsable.tsx';
+import { ResetButton } from '@/base/components/buttons/ResetButton.tsx';
 import Replay from '@mui/icons-material/Replay';
 import { Sources } from '@/features/source/services/Sources';
 
@@ -108,6 +113,34 @@ export const LibraryOptionsPanel = ({
         (tracker) => categoryLibraryOptions.hasTrackerBinding[tracker.id] != null,
     );
     const isSourceFilterActive = librarySources.some((source) => categoryLibraryOptions.hasSource[source.id] != null);
+    const areFiltersActive =
+        categoryLibraryOptions.hasUnreadChapters != null ||
+        categoryLibraryOptions.hasReadChapters != null ||
+        categoryLibraryOptions.hasDownloadedChapters != null ||
+        categoryLibraryOptions.hasBookmarkedChapters != null ||
+        categoryLibraryOptions.hasDuplicateChapters != null ||
+        isStatusFilterActive ||
+        isTrackerFilterActive ||
+        isSourceFilterActive;
+
+    const resetFilters = () => {
+        batchUpdateCategoryMetadata([
+            {
+                categories: [category],
+                entries: [
+                    { metadataKey: 'hasUnreadChapters', value: undefined },
+                    { metadataKey: 'hasReadChapters', value: undefined },
+                    { metadataKey: 'hasDownloadedChapters', value: undefined },
+                    { metadataKey: 'hasBookmarkedChapters', value: undefined },
+                    { metadataKey: 'hasDuplicateChapters', value: undefined },
+                    { metadataKey: 'hasStatus', value: {} },
+                    { metadataKey: 'hasTrackerBinding', value: {} },
+                    { metadataKey: 'hasSource', value: {} },
+                ],
+            },
+        ]).catch((e) => makeToast(t`Failed to reset filters`, 'error', getErrorMessage(e)));
+        onClose();
+    };
 
     return (
         <OptionsTabs<'filter' | 'sort' | 'display'>
@@ -119,6 +152,13 @@ export const LibraryOptionsPanel = ({
                 if (key === 'filter') {
                     return (
                         <>
+                            {areFiltersActive && (
+                                <ResetButton
+                                    onClick={resetFilters}
+                                    sx={{ alignSelf: 'flex-start' }}
+                                    variant="outlined"
+                                />
+                            )}
                             <ThreeStateCheckboxInput
                                 label={t`Unread`}
                                 checked={categoryLibraryOptions.hasUnreadChapters}

--- a/src/features/library/components/LibraryToolbarMenu.tsx
+++ b/src/features/library/components/LibraryToolbarMenu.tsx
@@ -33,15 +33,23 @@ export const LibraryToolbarMenu = ({
 
     const [open, setOpen] = useState(false);
     const options = getCategoryMetadata(category);
+
+    const isStatusFilterActive = Object.values(options.hasStatus).some((hasStatus) => hasStatus != null);
+    const isTrackerFilterActive = Object.values(options.hasTrackerBinding).some(
+        (trackerFilterStatus) => trackerFilterStatus != null,
+    );
+    const isSourceFilterActive = Object.values(options.hasSource).some(
+        (sourceFilterStatus) => sourceFilterStatus != null,
+    );
     const active =
         options.hasDownloadedChapters != null ||
         options.hasUnreadChapters != null ||
         options.hasReadChapters != null ||
         options.hasBookmarkedChapters != null ||
         options.hasDuplicateChapters != null ||
-        Object.values(options.hasStatus).some((hasStatus) => hasStatus != null) ||
-        Object.values(options.hasTrackerBinding).some((trackerFilterStatus) => trackerFilterStatus != null) ||
-        Object.values(options.hasSource).some((sourceFilterStatus) => sourceFilterStatus != null);
+        isSourceFilterActive ||
+        isTrackerFilterActive ||
+        isStatusFilterActive;
 
     return (
         <>
@@ -69,7 +77,15 @@ export const LibraryToolbarMenu = ({
                     <FilterList />
                 </IconButton>
             </CustomTooltip>
-            <LibraryOptionsPanel category={category} open={open} onClose={() => setOpen(false)} />
+            <LibraryOptionsPanel
+                category={category}
+                open={open}
+                onClose={() => setOpen(false)}
+                active={active}
+                isStatusFilterActive={isStatusFilterActive}
+                isTrackerFilterActive={isTrackerFilterActive}
+                isSourceFilterActive={isSourceFilterActive}
+            />
         </>
     );
 };

--- a/src/i18n/locales/en.po
+++ b/src/i18n/locales/en.po
@@ -1767,6 +1767,10 @@ msgstr "Failed to connect to KOReader Sync server."
 msgid "Failed to disconnect from KOReader Sync server."
 msgstr "Failed to disconnect from KOReader Sync server."
 
+#: src/features/library/components/LibraryOptionsPanel.tsx
+msgid "Failed to reset filters"
+msgstr "Failed to reset filters"
+
 #: src/features/backup/screens/Backup.tsx
 #: src/features/browse/extensions/Extensions.tsx
 #: src/features/browse/screens/BrowseSettings.tsx

--- a/src/i18n/locales/en.po
+++ b/src/i18n/locales/en.po
@@ -1189,6 +1189,10 @@ msgstr "Could not remove extension store \"{name}\""
 msgid "Could not remove non library manga from categories"
 msgstr "Could not remove non library manga from categories"
 
+#: src/features/library/components/LibraryOptionsPanel.tsx
+msgid "Could not reset filters"
+msgstr "Could not reset filters"
+
 #: src/features/backup/screens/Backup.tsx
 msgid "Could not restore backup"
 msgstr "Could not restore backup"
@@ -1766,10 +1770,6 @@ msgstr "Failed to connect to KOReader Sync server."
 #: src/features/settings/components/koreaderSync/KoreaderSyncSettings.tsx
 msgid "Failed to disconnect from KOReader Sync server."
 msgstr "Failed to disconnect from KOReader Sync server."
-
-#: src/features/library/components/LibraryOptionsPanel.tsx
-msgid "Failed to reset filters"
-msgstr "Failed to reset filters"
 
 #: src/features/backup/screens/Backup.tsx
 #: src/features/browse/extensions/Extensions.tsx


### PR DESCRIPTION
I find myself wanting to reset library filters more often now that source filters are available, so this adds a **Reset** button similar to source search. It appears only when filters are active and resets the current category’s filters.