### PR TITLE
Fix restored theme mode

### DIFF
--- a/src/features/settings/screens/Appearance.tsx
+++ b/src/features/settings/screens/Appearance.tsx
@@ -13,7 +13,6 @@ import MenuItem from '@mui/material/MenuItem';
 import ListSubheader from '@mui/material/ListSubheader';
 import Switch from '@mui/material/Switch';
 import Link from '@mui/material/Link';
-import { useColorScheme } from '@mui/material/styles';
 import { useLingui } from '@lingui/react/macro';
 import { useAppThemeContext } from '@/features/theme/AppThemeContext.tsx';
 import { Select } from '@/base/components/inputs/Select.tsx';
@@ -41,8 +40,6 @@ import { MUI_THEME_MODE_KEY } from '@/lib/mui/MUI.constants.ts';
 export const Appearance = () => {
     const { t } = useLingui();
     const { themeMode, setThemeMode, shouldUsePureBlackMode, setShouldUsePureBlackMode } = useAppThemeContext();
-    const { mode, setMode } = useColorScheme();
-    const actualThemeMode = (mode ?? themeMode) as ThemeMode;
 
     useAppTitle(t`Appearance`);
 
@@ -54,7 +51,7 @@ export const Appearance = () => {
         makeToast(t`Failed to save changes`, 'error', getErrorMessage(e)),
     );
 
-    const isDarkMode = MediaQuery.getThemeMode(actualThemeMode) === ThemeMode.DARK;
+    const isDarkMode = MediaQuery.getThemeMode(themeMode) === ThemeMode.DARK;
 
     if (loading) {
         return <LoadingPlaceholder />;
@@ -81,13 +78,11 @@ export const Appearance = () => {
             <ListItem>
                 <ListItemText primary={t`Theme mode`} />
                 <Select<ThemeMode>
-                    value={actualThemeMode}
+                    value={themeMode}
                     onChange={(e) => {
                         const newMode = e.target.value as 'system' | 'light' | 'dark';
 
                         setThemeMode(newMode as ThemeMode);
-                        setMode(newMode);
-                        // in case a non "colorSchemes" mui theme is active, "setMode" does not update the mode ("mui-mode") value
                         AppStorage.local.setItem(MUI_THEME_MODE_KEY, newMode, true);
                     }}
                 >

--- a/src/features/theme/services/ThemeCreator.ts
+++ b/src/features/theme/services/ThemeCreator.ts
@@ -180,8 +180,14 @@ export const createTheme = (
     const setPureBlackMode = isDarkMode && pureBlackMode;
 
     const appColorTheme = createAppColorTheme(appTheme.muiTheme, dynamicColor, setPureBlackMode, mode);
+    const { colorSchemes, defaultColorScheme: _defaultColorScheme, ...baseAppColorTheme } = appColorTheme;
+    const activeColorScheme = colorSchemes?.[mode];
+    const activeAppColorTheme = deepmerge(
+        baseAppColorTheme,
+        deepmerge(typeof activeColorScheme === 'object' ? activeColorScheme : {}, { palette: { mode } }),
+    );
 
-    const themeForColors = createMuiTheme({ ...appColorTheme, defaultColorScheme: mode });
+    const themeForColors = createMuiTheme(activeAppColorTheme);
 
     // only style scrollbar for devices that support hovering; otherwise, they most likely are touch devices that should
     // use the native scrollbar.
@@ -190,8 +196,7 @@ export const createTheme = (
     const doesDeviceSupportHover = window.matchMedia('hover: hover').matches;
 
     const suwayomiTheme = createMuiTheme(
-        deepmerge(appColorTheme, {
-            defaultColorScheme: mode,
+        deepmerge(activeAppColorTheme, {
             direction,
             typography: {
                 fontSize: 13,


### PR DESCRIPTION
## Summary

- Resolve the active color scheme before passing the theme to MUI.
- Use Suwayomi's server-backed theme mode as the single source of truth in Appearance settings.
- Preserve the namespaced local fallback used during startup before metadata loads.

## Root cause

Suwayomi restores and resolves `themeMode`, but the final theme still included both MUI `colorSchemes`. MUI therefore initialized a second theme-mode state from browser-side storage (`mui-mode`). Restoring Dark from server metadata could produce a dark generated background while MUI independently selected light-mode foreground colors.

Appearance settings also preferred MUI's local mode over the restored server value, which is why the broken state misleadingly displayed System.

This change gives `ThemeProvider` a single resolved palette. MUI no longer owns an independently switchable mode, while Suwayomi continues to resolve System and rebuild the theme when the system scheme changes.

Fixes #1150.

This is a minimized follow-up to the original report in #1146.

## Validation

- `pnpm format:check`
- `pnpm lint`
- `pnpm tsc`
- `pnpm build`
- Isolated A/B test using the same current `upstream/master` frontend and Suwayomi Server preview `v2.3.2333`:
  - Master after restoring only Dark under a light browser scheme: background `rgb(3, 5, 12)`, text `rgba(0, 0, 0, 0.87)`, `color-scheme: light`, Appearance reports System.
  - This fix: background `rgb(3, 5, 12)`, text `rgb(255, 255, 255)`, `color-scheme: dark`, Appearance reports Dark.
- Verified explicit Light, System under light and dark browser schemes, Pure black, Ying & Yang, reload persistence, isolated-container restart, and a fresh browser origin.
- The production Suwayomi stack was not modified.
