### PR TITLE
feat: add a sync button to the app bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - (**Download**) Add button to retry all failed downloads
 - (**Reader**) Add fullscreen setting (does nothing on iOS)
 - (**Library**) Add `reset` button to library filters
+- (**Sync**) Add sync button to the app bar of the library and updates pages
 
 ### Changed
 

--- a/src/features/library/screens/Library.tsx
+++ b/src/features/library/screens/Library.tsx
@@ -25,6 +25,7 @@ import { LibraryToolbarMenu } from '@/features/library/components/LibraryToolbar
 import { LibraryMangaGrid } from '@/features/library/components/LibraryMangaGrid.tsx';
 import { AppbarSearch } from '@/base/components/AppbarSearch.tsx';
 import { UpdateChecker } from '@/features/updates/components/UpdateChecker.tsx';
+import { SyncButton } from '@/features/sync/components/SyncButton.tsx';
 import { useSelectableCollection } from '@/base/collection/hooks/useSelectableCollection.ts';
 import { SelectableCollectionSelectMode } from '@/base/collection/components/SelectableCollectionSelectMode.tsx';
 import { useGetVisibleLibraryMangas } from '@/features/library/hooks/useGetVisibleLibraryMangas.ts';
@@ -217,6 +218,7 @@ export function Library() {
                 <>
                     <AppbarSearch />
                     <LibraryToolbarMenu category={activeTab} mangas={mangas} />
+                    <SyncButton />
                     <UpdateChecker categoryId={activeTab?.id} />
                 </>
             )}

--- a/src/features/navigation-bar/components/DefaultNavBar.tsx
+++ b/src/features/navigation-bar/components/DefaultNavBar.tsx
@@ -24,7 +24,6 @@ import { DesktopSideBar } from '@/features/navigation-bar/components/DesktopSide
 import { useResizeObserver } from '@/base/hooks/useResizeObserver.tsx';
 import { MobileBottomBar } from '@/features/navigation-bar/components/MobileBottomBar.tsx';
 import { useNavBarContext } from '@/features/navigation-bar/NavbarContext.tsx';
-import { SyncButton } from '@/features/sync/components/SyncButton.tsx';
 import { useMetadataServerSettings } from '@/features/settings/services/ServerSettingsMetadata.ts';
 import { NAVIGATION_BAR_ITEMS } from '@/features/navigation-bar/NavigationBar.constants.ts';
 import { NavigationBarUtil } from '@/features/navigation-bar/NavigationBar.util.ts';
@@ -167,7 +166,6 @@ export function DefaultNavBar() {
                         >
                             {title}
                         </Typography>
-                        <SyncButton />
                         {action}
                     </Stack>
                 </Toolbar>

--- a/src/features/navigation-bar/components/DefaultNavBar.tsx
+++ b/src/features/navigation-bar/components/DefaultNavBar.tsx
@@ -24,6 +24,7 @@ import { DesktopSideBar } from '@/features/navigation-bar/components/DesktopSide
 import { useResizeObserver } from '@/base/hooks/useResizeObserver.tsx';
 import { MobileBottomBar } from '@/features/navigation-bar/components/MobileBottomBar.tsx';
 import { useNavBarContext } from '@/features/navigation-bar/NavbarContext.tsx';
+import { SyncButton } from '@/features/sync/components/SyncButton.tsx';
 import { useMetadataServerSettings } from '@/features/settings/services/ServerSettingsMetadata.ts';
 import { NAVIGATION_BAR_ITEMS } from '@/features/navigation-bar/NavigationBar.constants.ts';
 import { NavigationBarUtil } from '@/features/navigation-bar/NavigationBar.util.ts';
@@ -166,6 +167,7 @@ export function DefaultNavBar() {
                         >
                             {title}
                         </Typography>
+                        <SyncButton />
                         {action}
                     </Stack>
                 </Toolbar>

--- a/src/features/sync/components/SyncButton.tsx
+++ b/src/features/sync/components/SyncButton.tsx
@@ -47,9 +47,13 @@ export function SyncButton() {
 
     return (
         <CustomTooltip title={isSyncing ? t(SYNC_STATE_TRANSLATION[syncState]) : t`Sync now`}>
-            <IconButton onClick={startSync} disabled={isSyncing} color="inherit">
-                {isSyncing ? <CircularProgress size={24} color="inherit" /> : <CloudSyncIcon />}
-            </IconButton>
+            {isSyncing ? (
+                <CircularProgress size={24} color="inherit" />
+            ) : (
+                <IconButton onClick={startSync} disabled={isSyncing} color="inherit">
+                    <CloudSyncIcon />
+                </IconButton>
+            )}
         </CustomTooltip>
     );
 }

--- a/src/features/sync/components/SyncButton.tsx
+++ b/src/features/sync/components/SyncButton.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import IconButton from '@mui/material/IconButton';
+import CircularProgress from '@mui/material/CircularProgress';
+import CloudSyncIcon from '@mui/icons-material/CloudSync';
+import { useLingui } from '@lingui/react/macro';
+import { CustomTooltip } from '@/base/components/CustomTooltip.tsx';
+import { requestManager } from '@/lib/requests/RequestManager.ts';
+import { makeToast } from '@/base/utils/Toast.ts';
+import { getErrorMessage } from '@/lib/HelperFunctions.ts';
+import { StartSyncResult, SyncState } from '@/lib/graphql/generated/graphql-base.types.ts';
+import { SYNC_START_RESULT_TRANSLATION, SYNC_STATE_TRANSLATION } from '@/features/settings/Settings.constants.ts';
+
+export function SyncButton() {
+    const { t } = useLingui();
+
+    const { data: settingsData } = requestManager.useGetServerSettings();
+    const { data: syncStatusData } = requestManager.useGetSyncStatus();
+
+    const syncState = syncStatusData?.lastSyncStatus?.state;
+    const isSyncing = !!syncState && ![SyncState.Success, SyncState.Error].includes(syncState);
+
+    if (!settingsData?.settings.syncYomiEnabled) {
+        return null;
+    }
+
+    const startSync = async () => {
+        try {
+            const response = await requestManager.startSync().response;
+            const result = response.data?.startSync.result;
+            if (result) {
+                makeToast(
+                    t(SYNC_START_RESULT_TRANSLATION[result]),
+                    result === StartSyncResult.Success ? 'success' : 'warning',
+                );
+            }
+        } catch (e) {
+            makeToast(t`Could not start sync`, 'error', getErrorMessage(e));
+        }
+    };
+
+    return (
+        <CustomTooltip title={isSyncing ? t(SYNC_STATE_TRANSLATION[syncState]) : t`Sync now`}>
+            <IconButton onClick={startSync} disabled={isSyncing} color="inherit">
+                {isSyncing ? <CircularProgress size={24} color="inherit" /> : <CloudSyncIcon />}
+            </IconButton>
+        </CustomTooltip>
+    );
+}

--- a/src/features/updates/screens/Updates.tsx
+++ b/src/features/updates/screens/Updates.tsx
@@ -13,6 +13,7 @@ import { requestManager } from '@/lib/requests/RequestManager.ts';
 import { LoadingPlaceholder } from '@/base/components/feedback/LoadingPlaceholder.tsx';
 import { EmptyViewAbsoluteCentered } from '@/base/components/feedback/EmptyViewAbsoluteCentered.tsx';
 import { UpdateChecker } from '@/features/updates/components/UpdateChecker.tsx';
+import { SyncButton } from '@/features/sync/components/SyncButton.tsx';
 import { StyledGroupedVirtuoso } from '@/base/components/virtuoso/StyledGroupedVirtuoso.tsx';
 import { StyledGroupHeader } from '@/base/components/virtuoso/StyledGroupHeader.tsx';
 import { StyledGroupItemWrapper } from '@/base/components/virtuoso/StyledGroupItemWrapper.tsx';
@@ -34,7 +35,13 @@ import { useElementSize } from '@mantine/hooks';
 export const Updates: React.FC = () => {
     const { t } = useLingui();
 
-    useAppTitleAndAction(t`Updates`, <UpdateChecker />);
+    useAppTitleAndAction(
+        t`Updates`,
+        <>
+            <SyncButton />
+            <UpdateChecker />
+        </>,
+    );
 
     const {
         data: chapterUpdateData,

--- a/src/i18n/locales/en.po
+++ b/src/i18n/locales/en.po
@@ -1233,6 +1233,7 @@ msgid "Could not search source"
 msgstr "Could not search source"
 
 #: src/features/settings/screens/ServerSettings.tsx
+#: src/features/sync/components/SyncButton.tsx
 msgid "Could not start sync"
 msgstr "Could not start sync"
 
@@ -3744,6 +3745,10 @@ msgstr "Sync in progress"
 #: src/features/settings/screens/ServerSettings.tsx
 msgid "Sync interval"
 msgstr "Sync interval"
+
+#: src/features/sync/components/SyncButton.tsx
+msgid "Sync now"
+msgstr "Sync now"
 
 #: src/features/settings/Settings.constants.ts
 msgid "Sync started"


### PR DESCRIPTION
Adds a cloud-sync icon to the app bar (shown only when sync is enabled on the server) that starts a manual sync on tap and shows a spinner while one is running.