### PR TITLE
fix: fix initial theme color restoration for subpath deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- (**Appearance**) Fix restoring the initial background and browser theme color when served from a subpath
 - (**Browse**) Fix filtering with nested group changes
 - (**Library**) Fix source filter potentially causing all manga to get filtered out
 - (**Chapter**) Fix missing chapters before the first available one not being considered in the total missing chapter count (Example: chapters 1-5 are missing, first available chapter is 6. Chapters 1-5 weren't counted as missing in the total missing chapter amount)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- (**Appearance**) Fix restoring the initial background and browser theme color when served from a subpath
 - (**Browse**) Fix filtering with nested group changes
 - (**Library**) Fix source filter potentially causing all manga to get filtered out
 - (**Chapter**) Fix missing chapters before the first available one not being considered in the total missing chapter count (Example: chapters 1-5 are missing, first available chapter is 6. Chapters 1-5 weren't counted as missing in the total missing chapter amount)

--- a/index.html
+++ b/index.html
@@ -27,7 +27,29 @@
         <script type="module" src="./src/index.tsx"></script>
         <script>
             const backgroundColor = (() => {
-                const storageValue = window.localStorage.getItem('theme_background');
+                let storageValue;
+                try {
+                    const storageKey = 'theme_background';
+                    const viteBaseUrl = '%BASE_URL%';
+                    const subpath = (() => {
+                        if (viteBaseUrl !== './') {
+                            return viteBaseUrl === '/' ? '' : viteBaseUrl;
+                        }
+
+                        const baseTag = document.querySelector('base');
+                        if (!baseTag) {
+                            return '';
+                        }
+
+                        return baseTag.href.replace(window.location.origin, '').slice(0, -1);
+                    })();
+                    const scopedStorageKey = `suwayomi_webui_${subpath}_${storageKey}`;
+                    storageValue = window.localStorage.getItem(scopedStorageKey);
+                } catch (error) {
+                    console.error('Failed to restore the initial theme background from local storage', error);
+                    return null;
+                }
+
                 try {
                     return JSON.parse(storageValue);
                 } catch (e) {

--- a/index.html
+++ b/index.html
@@ -29,13 +29,7 @@
             const backgroundColor = (() => {
                 let storageValue;
                 try {
-                    const storageKey = 'theme_background';
-                    const viteBaseUrl = '%BASE_URL%';
                     const subpath = (() => {
-                        if (viteBaseUrl !== './') {
-                            return viteBaseUrl === '/' ? '' : viteBaseUrl;
-                        }
-
                         const baseTag = document.querySelector('base');
                         if (!baseTag) {
                             return '';
@@ -43,10 +37,8 @@
 
                         return baseTag.href.replace(window.location.origin, '').slice(0, -1);
                     })();
-                    const scopedStorageKey = `suwayomi_webui_${subpath}_${storageKey}`;
-                    storageValue = window.localStorage.getItem(scopedStorageKey);
+                    storageValue = window.localStorage.getItem(`suwayomi_webui_${subpath}_theme_background`);
                 } catch (error) {
-                    console.error('Failed to restore the initial theme background from local storage', error);
                     return null;
                 }
 


### PR DESCRIPTION
# Fix initial theme color restoration for subpath deployments

## Summary

- Restore the initial page background and browser `theme-color` from the correct subpath-scoped storage key.
- Resolve the active subpath in both development and production deployments.
- Allow application startup to continue when browser storage is unavailable.

## Background

[PR #1063](https://github.com/Suwayomi/Suwayomi-WebUI/pull/1063) added an inline script that restores the last rendered background color before React loads. This prevents a mismatched initial background and keeps Android browser and PWA chrome aligned with the application theme.

[Commit 4d3653c](https://github.com/Suwayomi/Suwayomi-WebUI/commit/4d3653c44a96701779b95af2ce06b78391c83332) later introduced a subpath-related storage key naming rule. Application storage values such as `theme_background` are now stored under a physical key containing the current deployment subpath:

```text
suwayomi_webui_<subpath>_theme_background
```

However, the inline script in `index.html` continued reading the unscoped `theme_background` key. As a result, hard reloads could no longer restore the initial background or browser `theme-color`.

## Implementation

The startup script now constructs the same scoped storage key used by the application:

- During development, `%BASE_URL%` provides the configured base path.
- In production builds, where `%BASE_URL%` is `./`, the runtime subpath is derived from the server-injected `<base href>`.
- Root deployments continue using an empty subpath and the existing `suwayomi_webui__theme_background` key format.

Only the scoped key is read. The old unscoped key is not used as a fallback because `theme_background` is derived from the active theme rather than being source data. Using the global key could temporarily apply another instance's color when multiple instances share the same origin.

Subpath resolution and storage access are wrapped in `try/catch`. If browser storage is unavailable, the failure is logged and initial color restoration is skipped without preventing the application from starting.

The Unreleased changelog has also been updated.

## Android Chrome compatibility

Android PWA validation exposed a separate browser-side regression in Chrome 152.

With the same WebUI build and stored theme value:

- Chrome 151 correctly applied the restored `theme-color` to the PWA navigation bar.
- Chrome 152 correctly updated the `meta[name="theme-color"]` value but did not apply it to the navigation bar.
- Chrome 153 Beta restored the expected navigation bar color.

Chrome 152 introduced new edge-to-edge handling for installed PWAs that opt in through `viewport-fit=cover`, which Suwayomi WebUI uses:

- [Android: enable short-edges cutout mode in webapp and activity flows](https://chromium.googlesource.com/chromium/src/+/8a4da86073359b379a09589333de67d0d43268a0)

Chrome 153 subsequently added navigation bar coloring based on the installed web application's theme color:

- [Color installed web app navigation bar using the theme color](https://chromium.googlesource.com/chromium/src/+/0a6ab4f0e2ce17e572b05400ae6eacd7fc5389f0)

The Chrome 152 behavior is independent of the storage-key issue fixed by this PR: the scoped value is read successfully and the document metadata is updated correctly. Testing with Chrome 151 and Chrome 153 confirms that the restored value is applied as expected outside the Chrome 152 regression.

## Validation

- `pnpm tsc`
- `pnpm exec oxfmt --check index.html CHANGELOG.md`
- `pnpm exec vite build`
- Verified:
  - development subpath resolution;
  - production runtime `<base>` resolution;
  - root deployment key generation;
  - scoped storage lookup;
  - ignoring the old unscoped key;
  - graceful handling of browser storage access failures;
  - Android PWA behavior with Chrome 151, Chrome 152, and Chrome 153 Beta.